### PR TITLE
Skip redundant address translation

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -33,7 +33,7 @@ impl WasmRiscv {
 	}
 
 	pub fn run(&mut self, clocks: u32) {
-		for i in 0..clocks {
+		for _i in 0..clocks {
 			self.application.tick();
 		}
 	}


### PR DESCRIPTION
From #33.

This PR skips redundant address translation for accessing wider than a byte in a 4k size page.