### PR TITLE
Change Clint mtime count up frequency

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -275,7 +275,7 @@ impl Cpu {
 		self.pc
 	}
 
-	/// Runs program one cycle. Fetch, decode, and execution are completed in a cycle.
+	/// Runs program one cycle. Fetch, decode, and execution are completed in a cycle so far.
 	pub fn tick(&mut self) {
 		let instruction_address = self.pc;
 		match self.tick_operate() {

--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -27,12 +27,7 @@ impl Clint {
 	/// * `mip` CPU `mip` register. It can be updated if interrupt occurs.
 	pub fn tick(&mut self, mip: &mut u64) {
 		self.clock = self.clock.wrapping_add(1);
-
-		// core clock : mtime clock = 8 : 1 is just an arbiraty ratio.
-		// @TODO: Implement more properly
-		if (self.clock % 8) == 0 {
-			self.mtime = self.mtime.wrapping_add(1);
-		}
+		self.mtime = self.mtime.wrapping_add(1);
 
 		if (self.msip & 1) != 0 {
 			*mip |= MIP_MSIP;


### PR DESCRIPTION
Counting up `mtime` more frequently. This change leads to timer interrupt more quickly and we can expect Linux boot can be faster because it waits for timer interrupt a lot.