### PR TITLE
Edge-triggered UART and PLIC interrupts

### DIFF
--- a/src/device/uart.rs
+++ b/src/device/uart.rs
@@ -1,5 +1,15 @@
 use terminal::Terminal;
 
+const IER_RXINT_BIT: u8 = 0x1;
+const IER_THREINT_BIT: u8 = 0x2;
+
+const IIR_THR_EMPTY: u8 = 0x2;
+const IIR_RD_AVAILABLE: u8 = 0x4;
+const IIR_NO_INTERRUPT: u8 = 0x7;
+
+const LSR_DATA_AVAILABLE: u8 = 0x1;
+const LSR_THR_EMPTY: u8 = 0x20;
+
 /// Emulates UART. Refer to the [specification](http://www.ti.com/lit/ug/sprugp1/sprugp1.pdf)
 /// for the detail.
 pub struct Uart {
@@ -11,7 +21,9 @@ pub struct Uart {
 	lcr: u8, // line control register
 	mcr: u8, // modem control register
 	lsr: u8, // line status register
-	scr: u8, // scratch
+	scr: u8, // scratch,
+	thre_ip: bool,
+	interrupting: bool,
 	terminal: Box<dyn Terminal>
 }
 
@@ -23,11 +35,13 @@ impl Uart {
 			rbr: 0,
 			thr: 0,
 			ier: 0,
-			iir: 0x02,
+			iir: 0,
 			lcr: 0,
 			mcr: 0,
-			lsr: 0x20,
+			lsr: LSR_THR_EMPTY,
 			scr: 0,
+			thre_ip: false,
+			interrupting: false,
 			terminal: terminal
 		}
 	}
@@ -36,38 +50,67 @@ impl Uart {
 	/// at certain timing.
 	pub fn tick(&mut self) {
 		self.clock = self.clock.wrapping_add(1);
+		let mut rx_ip = false;
+
+		// Reads input.
 		// 0x38400 is just an arbitary number @TODO: Fix me
 		if (self.clock % 0x38400) == 0 && self.rbr == 0 {
 			let value = self.terminal.get_input();
 			if value != 0 {
 				self.rbr = value;
-				self.lsr |= 0x01;
+				self.lsr |= LSR_DATA_AVAILABLE;
+				self.update_iir();
+				if (self.ier & IER_RXINT_BIT) != 0 {
+					rx_ip = true;
+				}
 			}
 		}
+
+		// Writes output.
 		// 0x10 is just an arbitary number @TODO: Fix me
 		if (self.clock % 0x10) == 0 && self.thr != 0 {
 			self.terminal.put_byte(self.thr);
 			self.thr = 0;
-			self.lsr |= 0x20;
+			self.lsr |= LSR_THR_EMPTY;
+			self.update_iir();
+			if (self.ier & IER_THREINT_BIT) != 0 {
+				self.thre_ip = true;
+			}
+		}
+
+		if self.thre_ip || rx_ip {
+			self.interrupting = true;
+			self.thre_ip = false;
+		} else {
+			self.interrupting = false;
 		}
 	}
 
-	/// Indicates whether `Uart` raises an interrupt signal
-	pub fn is_interrupting(&mut self) -> bool {
-		if (self.ier & 0x1) != 0 {
-			if self.rbr != 0 {
-				self.iir = 0x04;
-				return true;
-			}
+	/// Indicates whether an interrupt happens in the current cycle.
+	/// Note: This behavior is for easily handling an interrupt as
+	/// "Edge-triggered" from `Uart` module user.
+	/// It doesn't seem to be mentioned in the UART specification
+	/// whether interrupt should be "Edge-triggered" or "Level-triggered" but
+	/// we implement it as "Edge-triggered" so far because it would support more
+	/// drivers. I speculate some drivers assume "Edge-triggered" interrupt
+	/// while drivers rarely rely on the behavior of "Level-triggered" interrupt
+	/// which keeps interrupting while interrupt pending signal is asserted.
+	pub fn is_interrupting(&self) -> bool {
+		self.interrupting
+	}
+
+	fn update_iir(&mut self) {
+		let rx_ip = (self.ier & IER_RXINT_BIT) != 0 && self.rbr != 0;
+		let thre_ip = (self.ier & IER_THREINT_BIT) != 0 && self.thr == 0;
+
+		// Which should be prioritized RX interrupt or THRE interrupt?
+		if rx_ip {
+			self.iir = IIR_RD_AVAILABLE;
+		} else if thre_ip {
+			self.iir = IIR_THR_EMPTY;
+		} else {
+			self.iir = IIR_NO_INTERRUPT;
 		}
-		if (self.ier & 0x2) != 0 {
-			if self.thr == 0 {
-				self.iir = 0x02;
-				return true;
-			}
-		}
-		self.iir = 0xf;
-		return false;
 	}
 
 	/// Loads register content
@@ -81,7 +124,8 @@ impl Uart {
 				true => {
 					let rbr = self.rbr;
 					self.rbr = 0;
-					self.lsr &= !0x01;
+					self.lsr &= !LSR_DATA_AVAILABLE;
+					self.update_iir();
 					rbr
 				},
 				false => 0 // @TODO: Implement properly
@@ -111,13 +155,22 @@ impl Uart {
 			0x10000000 => match (self.lcr >> 7) == 0 {
 				true => {
 					self.thr = value;
-					self.lsr &= !0x20;
+					self.lsr &= !LSR_THR_EMPTY;
+					self.update_iir();
 				},
 				false => {} // @TODO: Implement properly
 			},
 			0x10000001 => match (self.lcr >> 7) == 0 {
 				true => {
+					// This bahavior isn't written in the data sheet
+					// but some drivers seem to rely on it.
+					if (self.ier & IER_THREINT_BIT) == 0 &&
+						(value & IER_THREINT_BIT) != 0 &&
+						self.thr == 0 {
+						self.thre_ip = true;
+					}
 					self.ier = value;
+					self.update_iir();
 				},
 				false => {} // @TODO: Implement properly
 			},


### PR DESCRIPTION
It doesn't seem to be written in the UART specification whether an interrupt should be "Edge-triggered" or "Level-triggered".  But some drivers (e.g. the latest (Nov.1.2020) xv6-riscv uart driver) seems to rely on "Edge-triggered" interrupt.

I would implement the interrupts as "Edge-triggered". Because I think It would support more drivers. I speculate some drivers assume "Edge-triggered" interrupt while rarely drivers rely on the behavior of "Level-triggered" which keeps interrupting while interrupt pending bit is asserted.

This PR changes UART "Level-triggered" interrupt to "Edge-triggered". It keeps VirtIO disk interrupt unchanged but lets PLIC convert "Level-triggered" VirtIO disk interrupt to "Edge-triggered" I'm not sure if this PLIC change is correct but did that for the consistency. I may revert PLIC later if I find it's wrong.