### PR TITLE
changed Memory::init to utilize Vec::resize

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 /// Emulates main memory.
 pub struct Memory {
 	/// Memory content
@@ -18,11 +20,15 @@ impl Memory {
 	/// # Arguments
 	/// * `capacity`
 	pub fn init(&mut self, capacity: u64) {
-		for _i in 0..((capacity + 7) / 8) {
-			self.data.push(0);
-		}
+		// casting may fail on 32-bit targets, and an error here is more useful than one in a VM
+		// expecting more memory than it has
+		self.data.resize(
+			((capacity + 7) / 8).try_into()
+				.expect("unable to allocate, usize cannot handle the required capacity"),
+			0
+		);
 	}
-	
+
 	/// Reads a byte from memory.
 	///
 	/// # Arguments


### PR DESCRIPTION
a simple replacement to speed up the Memory initialization process

![benchmark](https://user-images.githubusercontent.com/53193460/200602905-e0f28d21-751f-4231-adf5-1e64f65fd29a.png)
