### PR TITLE
feat: verify the correctness of emulator with spike and riscv-arch-tests

### DIFF
--- a/cli/src/dummy_terminal.rs
+++ b/cli/src/dummy_terminal.rs
@@ -1,43 +1,40 @@
-use std::str;
 use std::io::{stdout, Write};
+use std::str;
 
 use riscv_emu_rust::terminal::Terminal;
 
 /// Dummy `Terminal`. Output will be displayed in command line
 /// and input will not be handled.
-pub struct DummyTerminal {
-}
+pub struct DummyTerminal {}
 
 impl DummyTerminal {
 	pub fn new() -> Self {
-		DummyTerminal {
-		}
+		DummyTerminal {}
 	}
 }
-	
+
 impl Terminal for DummyTerminal {
 	fn put_byte(&mut self, value: u8) {
 		let str = vec![value];
 		match str::from_utf8(&str) {
 			Ok(s) => {
 				print!("{}", s);
-			},
+			}
 			Err(_e) => {}
 		};
 		match stdout().flush() {
 			_ => {} // Ignoring error so far
 		};
 	}
-	
+
 	fn get_input(&mut self) -> u8 {
 		0
 	}
 
 	// Wasm specific methods. No use.
 
-	fn put_input(&mut self, _value: u8) {
-	}
-	
+	fn put_input(&mut self, _value: u8) {}
+
 	fn get_output(&mut self) -> u8 {
 		0
 	}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -53,6 +53,7 @@ fn main() -> std::io::Result<()> {
 		"page_cache",
 		"Enable experimental page cache optimization",
 	);
+	opts.optopt("s", "signature", "Write signature to file", "a.signature");
 
 	let matches = match opts.parse(&args[1..]) {
 		Ok(m) => m,
@@ -97,7 +98,13 @@ fn main() -> std::io::Result<()> {
 		None => vec![],
 	};
 
-	let elf_filename = args[1].clone();
+	if matches.free.is_empty() {
+		print_usage(&program, opts);
+		// @TODO: throw error?
+		return Ok(());
+	}
+
+	let elf_filename = matches.free[0].clone();
 	let mut elf_file = File::open(elf_filename)?;
 	let mut elf_contents = vec![];
 	elf_file.read_to_end(&mut elf_contents)?;
@@ -140,5 +147,10 @@ fn main() -> std::io::Result<()> {
 		emulator.enable_page_cache(true);
 	}
 	emulator.run();
+
+	if let Some(signature_file) = matches.opt_str("s") {
+		let mut file = File::create(signature_file)?;
+		emulator.write_signature(&mut file, 4)?;
+	}
 	Ok(())
 }

--- a/cli/src/popup_terminal.rs
+++ b/cli/src/popup_terminal.rs
@@ -1,13 +1,13 @@
 extern crate pancurses;
 
+use self::pancurses::*;
 use riscv_emu_rust::terminal::Terminal;
 use std::str;
-use self::pancurses::*;
 
 /// Popup `Terminal` used for desktop program.
 pub struct PopupTerminal {
 	window: Window,
-	in_escape_sequence: bool
+	in_escape_sequence: bool,
 }
 
 impl PopupTerminal {
@@ -20,11 +20,11 @@ impl PopupTerminal {
 		curs_set(0);
 		PopupTerminal {
 			window: window,
-			in_escape_sequence: false
+			in_escape_sequence: false,
 		}
 	}
 }
-	
+
 impl Terminal for PopupTerminal {
 	fn put_byte(&mut self, value: u8) {
 		// Cutting off escape sequence so far
@@ -44,21 +44,18 @@ impl Terminal for PopupTerminal {
 		self.window.printw(str::from_utf8(&str).unwrap());
 		self.window.refresh();
 	}
-	
+
 	fn get_input(&mut self) -> u8 {
 		match self.window.getch() {
-			Some(Input::Character(c)) => {
-				c as u8
-			},
-			_ => 0
+			Some(Input::Character(c)) => c as u8,
+			_ => 0,
 		}
 	}
 
 	// Wasm specific methods. No use.
-	
-	fn put_input(&mut self, _value: u8) {
-	}
-	
+
+	fn put_input(&mut self, _value: u8) {}
+
 	fn get_output(&mut self) -> u8 {
 		0 // dummy
 	}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.87"
+

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1806,7 +1806,7 @@ fn get_register_name(num: usize) -> &'static str {
 	}
 }
 
-const INSTRUCTION_NUM: usize = 121;
+const INSTRUCTION_NUM: usize = 124;
 
 // @TODO: Reorder in often used order as
 const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
@@ -1944,23 +1944,88 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 	},
 	Instruction {
 		mask: 0xf800707f,
+		data: 0x8000302f,
+		name: "AMOMIN.D",
+		operation: |cpu, word, _address| {
+			let f = parse_format_r(word);
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_doubleword(addr) {
+				Ok(data) => data as i64,
+				Err(e) => return Err(e),
+			};
+			let value = cpu.x[f.rs2];
+			let min = if orig <= value { orig } else { value };
+			match cpu.mmu.store_doubleword(addr, min as u64) {
+				Ok(()) => {},
+				Err(e) => return Err(e),
+			};
+			cpu.x[f.rd] = orig;
+			Ok(())
+		},
+		disassemble: dump_format_r,
+	},
+	Instruction {
+		mask: 0xf800707f,
+		data: 0xa000302f,
+		name: "AMOMAX.D",
+		operation: |cpu, word, _address| {
+			let f = parse_format_r(word);
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_doubleword(addr) {
+				Ok(data) => data as i64,
+				Err(e) => return Err(e),
+			};
+			let value = cpu.x[f.rs2];
+			let max = if orig >= value { orig } else { value };
+			match cpu.mmu.store_doubleword(addr, max as u64) {
+				Ok(()) => {},
+				Err(e) => return Err(e),
+			};
+			cpu.x[f.rd] = orig;
+			Ok(())
+		},
+		disassemble: dump_format_r,
+	},
+	Instruction {
+		mask: 0xf800707f,
+		data: 0xc000302f,
+		name: "AMOMINU.D",
+		operation: |cpu, word, _address| {
+			let f = parse_format_r(word);
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_doubleword(addr) {
+				Ok(data) => data,
+				Err(e) => return Err(e),
+			};
+			let value = cpu.x[f.rs2] as u64;
+			let min = if orig <= value { orig } else { value };
+			match cpu.mmu.store_doubleword(addr, min) {
+				Ok(()) => {},
+				Err(e) => return Err(e),
+			};
+			cpu.x[f.rd] = orig as i64;
+			Ok(())
+		},
+		disassemble: dump_format_r,
+	},
+	Instruction {
+		mask: 0xf800707f,
 		data: 0xe000302f,
 		name: "AMOMAXU.D",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			let tmp = match cpu.mmu.load_doubleword(cpu.x[f.rs1] as u64) {
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_doubleword(addr) {
 				Ok(data) => data,
 				Err(e) => return Err(e),
 			};
-			let max = match cpu.x[f.rs2] as u64 >= tmp {
-				true => cpu.x[f.rs2] as u64,
-				false => tmp,
-			};
-			match cpu.mmu.store_doubleword(cpu.x[f.rs1] as u64, max) {
+			let value = cpu.x[f.rs2] as u64;
+			let max = if orig >= value { orig } else { value };
+			match cpu.mmu.store_doubleword(addr, max) {
 				Ok(()) => {}
 				Err(e) => return Err(e),
 			};
-			cpu.x[f.rd] = tmp as i64;
+			cpu.x[f.rd] = orig as i64;
 			Ok(())
 		},
 		disassemble: dump_format_r,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -998,20 +998,48 @@ impl Cpu {
 						}
 					}
 					1 => {
-						// @TODO: Support C.JAL in 32-bit mode
-						// C.ADDIW
-						// addiw r, r, imm
-						let r = (halfword >> 7) & 0x1f;
-						let imm = match halfword & 0x1000 {
-							0x1000 => 0xffffffc0,
-							_ => 0
-						} | // imm[31:6] <= [12]
-						((halfword >> 7) & 0x20) | // imm[5] <= [12]
-						((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
-						if r != 0 {
-							return (imm << 20) | (r << 15) | (r << 7) | 0x1b;
+						match self.xlen {
+							Xlen::Bit32 => {
+								// C.JAL (RV32C only)
+								// jal x1, offset
+								let offset = match halfword & 0x1000 {
+									0x1000 => 0xfffff000,
+									_ => 0
+								} | // offset[31:12] <= [12]
+								((halfword >> 1) & 0x800) | // offset[11] <= [12]
+								((halfword >> 7) & 0x10) | // offset[4] <= [11]
+								((halfword >> 1) & 0x300) | // offset[9:8] <= [10:9]
+								((halfword << 2) & 0x400) | // offset[10] <= [8]
+								((halfword >> 1) & 0x40) | // offset[6] <= [7]
+								((halfword << 1) & 0x80) | // offset[7] <= [6]
+								((halfword >> 2) & 0xe) | // offset[3:1] <= [5:3]
+								((halfword << 3) & 0x20); // offset[5] <= [2]
+								let imm = ((offset >> 1) & 0x80000) | // imm[19] <= offset[20]
+									((offset << 8) & 0x7fe00) | // imm[18:9] <= offset[10:1]
+									((offset >> 3) & 0x100) | // imm[8] <= offset[11]
+									((offset >> 12) & 0xff); // imm[7:0] <= offset[19:12]
+								return (imm << 12) | (1 << 7) | 0x6f;
+							}
+							Xlen::Bit64 => {
+								// C.ADDIW (RV64C only)
+								let r = (halfword >> 7) & 0x1f;
+								let imm = match halfword & 0x1000 {
+									0x1000 => 0xffffffc0,
+									_ => 0
+								} | // imm[31:6] <= [12]
+								((halfword >> 7) & 0x20) | // imm[5] <= [12]
+								((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
+								if r == 0 {
+									// Reserved
+								} else if imm == 0 {
+									// sext.w rd
+									return (r << 15) | (r << 7) | 0x1b;
+								} else {
+									// addiw r, r, imm
+									return (imm << 20) | (r << 15) | (r << 7) | 0x1b;
+								}
+							}
 						}
-						// r == 0 is reserved instruction
 					}
 					2 => {
 						// C.LI

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3177,7 +3177,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SLL",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_shl(cpu.x[f.rs2] as u32));
+			let mask = match cpu.xlen {
+				Xlen::Bit32 => 0x1f, // 31 or 0b11111
+				Xlen::Bit64 => 0x3f, // 63 or 0b111111
+			};
+			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_shl(cpu.x[f.rs2] as u32 & mask));
 			Ok(())
 		},
 		disassemble: dump_format_r,
@@ -3364,9 +3368,13 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SRL",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
+			let mask = match cpu.xlen {
+				Xlen::Bit32 => 0x1f, // 31 or 0b11111
+				Xlen::Bit64 => 0x3f, // 63 or 0b111111
+			};
 			cpu.x[f.rd] = cpu.sign_extend(
 				cpu.unsigned_data(cpu.x[f.rs1])
-					.wrapping_shr(cpu.x[f.rs2] as u32) as i64,
+					.wrapping_shr(cpu.x[f.rs2] as u32 & mask) as i64,
 			);
 			Ok(())
 		},

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1806,7 +1806,7 @@ fn get_register_name(num: usize) -> &'static str {
 	}
 }
 
-const INSTRUCTION_NUM: usize = 117;
+const INSTRUCTION_NUM: usize = 120;
 
 // @TODO: Reorder in often used order as
 const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
@@ -1967,23 +1967,88 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 	},
 	Instruction {
 		mask: 0xf800707f,
+		data: 0x8000202f,
+		name: "AMOMIN.W",
+		operation: |cpu, word, _address| {
+			let f = parse_format_r(word);
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_word(addr) {
+				Ok(data) => data as i32,
+				Err(e) => return Err(e),
+			};
+			let value = cpu.x[f.rs2] as i32;
+			let min = if orig <= value { orig } else { value };
+			match cpu.mmu.store_word(addr, min as u32) {
+				Ok(()) => {}
+				Err(e) => return Err(e),
+			};
+			cpu.x[f.rd] = cpu.sign_extend(orig as i64);
+			Ok(())
+		},
+		disassemble: dump_format_r,
+	},
+	Instruction {
+		mask: 0xf800707f,
+		data: 0xa000202f,
+		name: "AMOMAX.W",
+		operation: |cpu, word, _address| {
+			let f = parse_format_r(word);
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_word(addr) {
+				Ok(data) => data as i32,
+				Err(e) => return Err(e),
+			};
+			let value = cpu.x[f.rs2] as i32;
+			let max = if orig >= value { orig } else { value };
+			match cpu.mmu.store_word(addr, max as u32) {
+				Ok(()) => {}
+				Err(e) => return Err(e),
+			};
+			cpu.x[f.rd] = cpu.sign_extend(orig as i64);
+			Ok(())
+		},
+		disassemble: dump_format_r,
+	},
+	Instruction {
+		mask: 0xf800707f,
+		data: 0xc000202f,
+		name: "AMOMINU.W",
+		operation: |cpu, word, _address| {
+			let f = parse_format_r(word);
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_word(addr) {
+				Ok(data) => data,
+				Err(e) => return Err(e),
+			};
+			let value = cpu.x[f.rs2] as u32;
+			let min = if orig <= value { orig } else { value };
+			match cpu.mmu.store_word(addr, min) {
+				Ok(()) => {}
+				Err(e) => return Err(e),
+			};
+			cpu.x[f.rd] = cpu.sign_extend(orig as i32 as i64);
+			Ok(())
+		},
+		disassemble: dump_format_r,
+	},
+	Instruction {
+		mask: 0xf800707f,
 		data: 0xe000202f,
 		name: "AMOMAXU.W",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			let tmp = match cpu.mmu.load_word(cpu.x[f.rs1] as u64) {
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_word(addr) {
 				Ok(data) => data,
 				Err(e) => return Err(e),
 			};
-			let max = match cpu.x[f.rs2] as u32 >= tmp {
-				true => cpu.x[f.rs2] as u32,
-				false => tmp,
-			};
-			match cpu.mmu.store_word(cpu.x[f.rs1] as u64, max) {
+			let value = cpu.x[f.rs2] as u32;
+			let max = if orig >= value { orig } else { value };
+			match cpu.mmu.store_word(addr, max) {
 				Ok(()) => {}
 				Err(e) => return Err(e),
 			};
-			cpu.x[f.rd] = tmp as i32 as i64;
+			cpu.x[f.rd] = cpu.sign_extend(orig as i32 as i64);
 			Ok(())
 		},
 		disassemble: dump_format_r,
@@ -3554,7 +3619,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			};
 			let result = (orig as u32) ^ (cpu.x[f.rs2] as u32);
 			match cpu.mmu.store_word(addr, result) {
-				Ok(()) => {},
+				Ok(()) => {}
 				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = orig;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1031,7 +1031,6 @@ impl Cpu {
 					}
 					2 => {
 						// C.LI
-						// addi rd, x0, imm
 						let r = (halfword >> 7) & 0x1f;
 						let imm = match halfword & 0x1000 {
 							0x1000 => 0xffffffc0,
@@ -1040,10 +1039,12 @@ impl Cpu {
 						((halfword >> 7) & 0x20) | // imm[5] <= [12]
 						((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
 						if r != 0 {
+							// addi rd, x0, imm
 							return (imm << 20) | (r << 7) | 0x13;
+						} else {
+							// HINT
+							return 0x13;
 						}
-						// @TODO: Support HINTs
-						// r == 0 is for HINTs
 					}
 					3 => {
 						let r = (halfword >> 7) & 0x1f; // [11:7]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3312,7 +3312,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 				Xlen::Bit64 => 0x3f,
 			};
 			let shamt = (word >> 20) & mask;
-			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] << shamt);
+			cpu.x[f.rd] = (cpu.x[f.rs1] << shamt);
 			Ok(())
 		},
 		disassemble: dump_format_r,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1063,6 +1063,10 @@ impl Cpu {
 							}
 							// nzimm == 0 is for reserved instruction
 						}
+						if r == 0 {
+							// NOP
+							return 0x13;
+						}
 					}
 					4 => {
 						let funct2 = (halfword >> 10) & 0x3; // [11:10]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1806,7 +1806,7 @@ fn get_register_name(num: usize) -> &'static str {
 	}
 }
 
-const INSTRUCTION_NUM: usize = 120;
+const INSTRUCTION_NUM: usize = 121;
 
 // @TODO: Reorder in often used order as
 const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
@@ -3620,6 +3620,27 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let result = (orig as u32) ^ (cpu.x[f.rs2] as u32);
 			match cpu.mmu.store_word(addr, result) {
 				Ok(()) => {}
+				Err(e) => return Err(e),
+			};
+			cpu.x[f.rd] = orig;
+			Ok(())
+		},
+		disassemble: dump_format_r,
+	},
+	Instruction {
+		mask: 0xf800707f,
+		data: 0x2000302f,
+		name: "AMOXOR.D",
+		operation: |cpu, word, _address| {
+			let f = parse_format_r(word);
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_doubleword(addr) {
+				Ok(data) => data as i64,
+				Err(e) => return Err(e),
+			};
+			let result = orig ^ cpu.x[f.rs2];
+			match cpu.mmu.store_doubleword(addr, result as u64) {
+				Ok(()) => {},
 				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = orig;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2710,7 +2710,8 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		operation: |cpu, word, _address| {
 			let f = parse_format_i(word);
 			let tmp = cpu.sign_extend(cpu.pc as i64);
-			cpu.pc = (cpu.x[f.rs1] as u64).wrapping_add(f.imm as u64);
+			// Clear LSB to ensure 2-byte instruction alignment per RISC-V spec
+			cpu.pc = ((cpu.x[f.rs1] as u64).wrapping_add(f.imm as u64)) & !1;
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -970,6 +970,7 @@ impl Cpu {
 			1 => {
 				match funct3 {
 					0 => {
+						// C.ADDI
 						let r = (halfword >> 7) & 0x1f; // [11:7]
 						let imm = match halfword & 0x1000 {
 							0x1000 => 0xffffffc0,
@@ -977,17 +978,24 @@ impl Cpu {
 						} | // imm[31:6] <= [12]
 						((halfword >> 7) & 0x20) | // imm[5] <= [12]
 						((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
-						if r == 0 && imm == 0 {
-							// C.NOP
-							// addi x0, x0, 0
-							return 0x13;
-						} else if r != 0 {
-							// C.ADDI
-							// addi r, r, imm
-							return (imm << 20) | (r << 15) | (r << 7) | 0x13;
+
+						match (r, imm) {
+							(0, 0) => {
+								// NOP
+								return 0x13;
+							}
+							(0, _) => {
+								// HINT
+								return 0x13;
+							}
+							(r, 0) => {
+								// HINT
+								return 0x13;
+							}
+							(r, imm) => {
+								return (imm << 20) | (r << 15) | (r << 7) | 0x13;
+							}
 						}
-						// @TODO: Support HINTs
-						// r == 0 and imm != 0 is HINTs
 					}
 					5 => {
 						// C.J

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1956,7 +1956,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let value = cpu.x[f.rs2];
 			let min = if orig <= value { orig } else { value };
 			match cpu.mmu.store_doubleword(addr, min as u64) {
-				Ok(()) => {},
+				Ok(()) => {}
 				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = orig;
@@ -1978,7 +1978,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let value = cpu.x[f.rs2];
 			let max = if orig >= value { orig } else { value };
 			match cpu.mmu.store_doubleword(addr, max as u64) {
-				Ok(()) => {},
+				Ok(()) => {}
 				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = orig;
@@ -2000,7 +2000,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let value = cpu.x[f.rs2] as u64;
 			let min = if orig <= value { orig } else { value };
 			match cpu.mmu.store_doubleword(addr, min) {
-				Ok(()) => {},
+				Ok(()) => {}
 				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = orig as i64;
@@ -2944,10 +2944,9 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "LD",
 		operation: |cpu, word, _address| {
 			let f = parse_format_i(word);
-			cpu.x[f.rd] = match cpu
-				.mmu
-				.load_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64)
-			{
+			let address = cpu.x[f.rs1].wrapping_add(f.imm) as u64;
+			let value = cpu.mmu.load_doubleword(address);
+			cpu.x[f.rd] = match value {
 				Ok(data) => data as i64,
 				Err(e) => return Err(e),
 			};
@@ -3058,7 +3057,9 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "LWU",
 		operation: |cpu, word, _address| {
 			let f = parse_format_i(word);
-			cpu.x[f.rd] = match cpu.mmu.load_word(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
+			let address = cpu.x[f.rs1].wrapping_add(f.imm) as u64;
+			let value = cpu.mmu.load_word(address);
+			cpu.x[f.rd] = match value {
 				Ok(data) => data as i64,
 				Err(e) => return Err(e),
 			};
@@ -3325,8 +3326,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SD",
 		operation: |cpu, word, _address| {
 			let f = parse_format_s(word);
-			cpu.mmu
-				.store_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u64)
+			let address = cpu.x[f.rs1].wrapping_add(f.imm) as u64;
+			let value = cpu.x[f.rs2] as u64;
+			match cpu.mmu.store_doubleword(address, value) {
+				Ok(()) => Ok(()),
+				Err(e) => Err(e),
+			}
 		},
 		disassemble: dump_format_s,
 	},
@@ -3371,27 +3376,28 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		data: 0x00001013,
 		name: "SLLI",
 		operation: |cpu, word, _address| {
-			let f = parse_format_r(word);
+			let f = parse_format_i(word);
 			let mask = match cpu.xlen {
 				Xlen::Bit32 => 0x1f,
 				Xlen::Bit64 => 0x3f,
 			};
-			let shamt = (word >> 20) & mask;
-			cpu.x[f.rd] = (cpu.x[f.rs1] << shamt);
+			let shamt = (f.imm & mask) as u32;
+			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_shl(shamt));
 			Ok(())
 		},
-		disassemble: dump_format_r,
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0xfe00707f,
 		data: 0x0000101b,
 		name: "SLLIW",
 		operation: |cpu, word, _address| {
-			let f = parse_format_r(word);
-			cpu.x[f.rd] = (cpu.x[f.rs1] << f.rs2) as i32 as i64;
+			let f = parse_format_i(word);
+			let shamt = (f.imm & 0x1f) as u32;
+			cpu.x[f.rd] = (cpu.x[f.rs1] << shamt) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r,
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3399,7 +3405,8 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SLLW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			cpu.x[f.rd] = (cpu.x[f.rs1] as u32).wrapping_shl(cpu.x[f.rs2] as u32) as i32 as i64;
+			let shamt = (cpu.x[f.rs2] & 0x1f) as u32;
+			cpu.x[f.rd] = (cpu.x[f.rs1] as u32).wrapping_shl(shamt) as i32 as i64;
 			Ok(())
 		},
 		disassemble: dump_format_r,
@@ -3476,12 +3483,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		data: 0x40005013,
 		name: "SRAI",
 		operation: |cpu, word, _address| {
-			let f = parse_format_r(word);
+			let f = parse_format_i(word);
 			let mask = match cpu.xlen {
 				Xlen::Bit32 => 0x1f,
 				Xlen::Bit64 => 0x3f,
 			};
-			let shamt = (word >> 20) & mask;
+			let shamt = (f.imm & mask) as u32;
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] >> shamt);
 			Ok(())
 		},
@@ -3492,8 +3499,9 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		data: 0x4000501b,
 		name: "SRAIW",
 		operation: |cpu, word, _address| {
-			let f = parse_format_r(word);
-			cpu.x[f.rd] = ((cpu.x[f.rs1] as i32) >> f.rs2) as i64;
+			let f = parse_format_i(word);
+			let shamt = (f.imm & 0x1f) as u32;
+			cpu.x[f.rd] = ((cpu.x[f.rs1] as i32) >> shamt) as i64;
 			Ok(())
 		},
 		disassemble: dump_format_r,
@@ -3504,7 +3512,8 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SRAW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			cpu.x[f.rd] = (cpu.x[f.rs1] as i32).wrapping_shr(cpu.x[f.rs2] as u32) as i64;
+			let shamt = (cpu.x[f.rs2] & 0x1f) as u32;
+			cpu.x[f.rd] = (cpu.x[f.rs1] as i32).wrapping_shr(shamt) as i64;
 			Ok(())
 		},
 		disassemble: dump_format_r,
@@ -3563,12 +3572,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		data: 0x00005013,
 		name: "SRLI",
 		operation: |cpu, word, _address| {
-			let f = parse_format_r(word);
+			let f = parse_format_i(word);
 			let mask = match cpu.xlen {
 				Xlen::Bit32 => 0x1f,
 				Xlen::Bit64 => 0x3f,
 			};
-			let shamt = (word >> 20) & mask;
+			let shamt = (f.imm & mask) as u32;
 			cpu.x[f.rd] = cpu.sign_extend((cpu.unsigned_data(cpu.x[f.rs1]) >> shamt) as i64);
 			Ok(())
 		},
@@ -3579,11 +3588,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		data: 0x0000501b,
 		name: "SRLIW",
 		operation: |cpu, word, _address| {
-			let f = parse_format_r(word);
-			cpu.x[f.rd] = ((cpu.x[f.rs1] as u32) >> f.rs2) as i32 as i64;
+			let f = parse_format_i(word);
+			let shamt = (f.imm & 0x1f) as u32;
+			cpu.x[f.rd] = ((cpu.x[f.rs1] as u32) >> shamt) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r,
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3591,7 +3601,8 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SRLW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			cpu.x[f.rd] = (cpu.x[f.rs1] as u32).wrapping_shr(cpu.x[f.rs2] as u32) as i32 as i64;
+			let shamt = (cpu.x[f.rs2] & 0x1f) as u32;
+			cpu.x[f.rd] = (cpu.x[f.rs1] as u32).wrapping_shr(shamt) as i32 as i64;
 			Ok(())
 		},
 		disassemble: dump_format_r,
@@ -3705,7 +3716,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			};
 			let result = orig ^ cpu.x[f.rs2];
 			match cpu.mmu.store_doubleword(addr, result as u64) {
-				Ok(()) => {},
+				Ok(()) => {}
 				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = orig;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -73,14 +73,13 @@ pub struct Cpu {
 	is_reservation_set: bool,
 	_dump_flag: bool,
 	decode_cache: DecodeCache,
-	unsigned_data_mask: u64
+	unsigned_data_mask: u64,
 }
 
 #[derive(Clone)]
 pub enum Xlen {
 	Bit32,
-	Bit64
-	// @TODO: Support Bit128
+	Bit64, // @TODO: Support Bit128
 }
 
 #[derive(Clone)]
@@ -89,12 +88,12 @@ pub enum PrivilegeMode {
 	User,
 	Supervisor,
 	Reserved,
-	Machine
+	Machine,
 }
 
 pub struct Trap {
 	pub trap_type: TrapType,
-	pub value: u64 // Trap type specific value
+	pub value: u64, // Trap type specific value
 }
 
 #[allow(dead_code)]
@@ -121,7 +120,7 @@ pub enum TrapType {
 	MachineTimerInterrupt,
 	UserExternalInterrupt,
 	SupervisorExternalInterrupt,
-	MachineExternalInterrupt
+	MachineExternalInterrupt,
 }
 
 fn _get_privilege_mode_name(mode: &PrivilegeMode) -> &'static str {
@@ -129,7 +128,7 @@ fn _get_privilege_mode_name(mode: &PrivilegeMode) -> &'static str {
 		PrivilegeMode::User => "User",
 		PrivilegeMode::Supervisor => "Supervisor",
 		PrivilegeMode::Reserved => "Reserved",
-		PrivilegeMode::Machine => "Machine"
+		PrivilegeMode::Machine => "Machine",
 	}
 }
 
@@ -139,7 +138,7 @@ fn get_privilege_encoding(mode: &PrivilegeMode) -> u8 {
 		PrivilegeMode::User => 0,
 		PrivilegeMode::Supervisor => 1,
 		PrivilegeMode::Reserved => panic!(),
-		PrivilegeMode::Machine => 3
+		PrivilegeMode::Machine => 3,
 	}
 }
 
@@ -149,7 +148,7 @@ pub fn get_privilege_mode(encoding: u64) -> PrivilegeMode {
 		0 => PrivilegeMode::User,
 		1 => PrivilegeMode::Supervisor,
 		3 => PrivilegeMode::Machine,
-		_ => panic!("Unknown privilege uncoding")
+		_ => panic!("Unknown privilege uncoding"),
 	}
 }
 
@@ -177,7 +176,7 @@ fn _get_trap_type_name(trap_type: &TrapType) -> &'static str {
 		TrapType::MachineTimerInterrupt => "MachineTimerInterrupt",
 		TrapType::UserExternalInterrupt => "UserExternalInterrupt",
 		TrapType::SupervisorExternalInterrupt => "SupervisorExternalInterrupt",
-		TrapType::MachineExternalInterrupt => "MachineExternalInterrupt"
+		TrapType::MachineExternalInterrupt => "MachineExternalInterrupt",
 	}
 }
 
@@ -209,7 +208,7 @@ fn get_trap_cause(trap: &Trap, xlen: &Xlen) -> u64 {
 		TrapType::MachineTimerInterrupt => interrupt_bit + 7,
 		TrapType::UserExternalInterrupt => interrupt_bit + 8,
 		TrapType::SupervisorExternalInterrupt => interrupt_bit + 9,
-		TrapType::MachineExternalInterrupt => interrupt_bit + 11
+		TrapType::MachineExternalInterrupt => interrupt_bit + 11,
 	}
 }
 
@@ -233,7 +232,7 @@ impl Cpu {
 			is_reservation_set: false,
 			_dump_flag: false,
 			decode_cache: DecodeCache::new(),
-			unsigned_data_mask: 0xffffffffffffffff
+			unsigned_data_mask: 0xffffffffffffffff,
 		};
 		cpu.x[0xb] = 0x1020; // I don't know why but Linux boot seems to require this initialization
 		cpu.write_csr_raw(CSR_MISA_ADDRESS, 0x800000008014312f);
@@ -256,7 +255,7 @@ impl Cpu {
 		self.xlen = xlen.clone();
 		self.unsigned_data_mask = match xlen {
 			Xlen::Bit32 => 0xffffffff,
-			Xlen::Bit64 => 0xffffffffffffffff
+			Xlen::Bit64 => 0xffffffffffffffff,
 		};
 		self.mmu.update_xlen(xlen.clone());
 	}
@@ -269,7 +268,7 @@ impl Cpu {
 		debug_assert!(reg <= 31, "reg must be 0-31. {}", reg);
 		match reg {
 			0 => 0, // 0th register is hardwired zero
-			_ => self.x[reg as usize]
+			_ => self.x[reg as usize],
 		}
 	}
 
@@ -282,8 +281,8 @@ impl Cpu {
 	pub fn tick(&mut self) {
 		let instruction_address = self.pc;
 		match self.tick_operate() {
-			Ok(()) => {},
-			Err(e) => self.handle_exception(e, instruction_address)
+			Ok(()) => {}
+			Err(e) => self.handle_exception(e, instruction_address),
 		}
 		self.mmu.tick(&mut self.csr[CSR_MIP_ADDRESS as usize]);
 		self.handle_interrupt(self.pc);
@@ -298,8 +297,7 @@ impl Cpu {
 	// @TODO: Rename?
 	fn tick_operate(&mut self) -> Result<(), Trap> {
 		if self.wfi {
-			if (self.read_csr_raw(CSR_MIE_ADDRESS) &
-				self.read_csr_raw(CSR_MIP_ADDRESS)) != 0{
+			if (self.read_csr_raw(CSR_MIE_ADDRESS) & self.read_csr_raw(CSR_MIP_ADDRESS)) != 0 {
 				self.wfi = false;
 			}
 			return Ok(());
@@ -307,14 +305,14 @@ impl Cpu {
 
 		let original_word = match self.fetch() {
 			Ok(word) => word,
-			Err(e) => return Err(e)
+			Err(e) => return Err(e),
 		};
 		let instruction_address = self.pc;
 		let word = match (original_word & 0x3) == 0x3 {
 			true => {
 				self.pc = self.pc.wrapping_add(4); // 32-bit length non-compressed instruction
 				original_word
-			},
+			}
 			false => {
 				self.pc = self.pc.wrapping_add(2); // 16-bit length compressed instruction
 				self.uncompress(original_word & 0xffff)
@@ -326,9 +324,12 @@ impl Cpu {
 				let result = (inst.operation)(self, word, instruction_address);
 				self.x[0] = 0; // hardwired zero
 				return result;
-			},
+			}
 			Err(()) => {
-				panic!("Unknown instruction PC:{:x} WORD:{:x}", instruction_address, original_word);
+				panic!(
+					"Unknown instruction PC:{:x} WORD:{:x}",
+					instruction_address, original_word
+				);
 			}
 		};
 	}
@@ -344,9 +345,9 @@ impl Cpu {
 				Ok(index) => {
 					self.decode_cache.insert(word, index);
 					Ok(&INSTRUCTIONS[index])
-				},
-				Err(()) => Err(())
-			}
+				}
+				Err(()) => Err(()),
+			},
 		}
 	}
 
@@ -357,7 +358,7 @@ impl Cpu {
 	fn decode_raw(&self, word: u32) -> Result<&Instruction, ()> {
 		match self.decode_and_get_instruction_index(word) {
 			Ok(index) => Ok(&INSTRUCTIONS[index]),
-			Err(()) => Err(())
+			Err(()) => Err(()),
 		}
 	}
 
@@ -373,7 +374,7 @@ impl Cpu {
 				return Ok(i);
 			}
 		}
-		return Err(())
+		return Err(());
 	}
 
 	fn handle_interrupt(&mut self, instruction_address: u64) {
@@ -381,62 +382,104 @@ impl Cpu {
 		let minterrupt = self.read_csr_raw(CSR_MIP_ADDRESS) & self.read_csr_raw(CSR_MIE_ADDRESS);
 
 		if (minterrupt & MIP_MEIP) != 0 {
-			if self.handle_trap(Trap {
-				trap_type: TrapType::MachineExternalInterrupt,
-				value: self.pc // dummy
-			}, instruction_address, true) {
+			if self.handle_trap(
+				Trap {
+					trap_type: TrapType::MachineExternalInterrupt,
+					value: self.pc, // dummy
+				},
+				instruction_address,
+				true,
+			) {
 				// Who should clear mip bit?
-				self.write_csr_raw(CSR_MIP_ADDRESS, self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_MEIP);
+				self.write_csr_raw(
+					CSR_MIP_ADDRESS,
+					self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_MEIP,
+				);
 				self.wfi = false;
 				return;
 			}
 		}
 		if (minterrupt & MIP_MSIP) != 0 {
-			if self.handle_trap(Trap {
-				trap_type: TrapType::MachineSoftwareInterrupt,
-				value: self.pc // dummy
-			}, instruction_address, true) {
-				self.write_csr_raw(CSR_MIP_ADDRESS, self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_MSIP);
+			if self.handle_trap(
+				Trap {
+					trap_type: TrapType::MachineSoftwareInterrupt,
+					value: self.pc, // dummy
+				},
+				instruction_address,
+				true,
+			) {
+				self.write_csr_raw(
+					CSR_MIP_ADDRESS,
+					self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_MSIP,
+				);
 				self.wfi = false;
 				return;
 			}
 		}
 		if (minterrupt & MIP_MTIP) != 0 {
-			if self.handle_trap(Trap {
-				trap_type: TrapType::MachineTimerInterrupt,
-				value: self.pc // dummy
-			}, instruction_address, true) {
-				self.write_csr_raw(CSR_MIP_ADDRESS, self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_MTIP);
+			if self.handle_trap(
+				Trap {
+					trap_type: TrapType::MachineTimerInterrupt,
+					value: self.pc, // dummy
+				},
+				instruction_address,
+				true,
+			) {
+				self.write_csr_raw(
+					CSR_MIP_ADDRESS,
+					self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_MTIP,
+				);
 				self.wfi = false;
 				return;
 			}
 		}
 		if (minterrupt & MIP_SEIP) != 0 {
-			if self.handle_trap(Trap {
-				trap_type: TrapType::SupervisorExternalInterrupt,
-				value: self.pc // dummy
-			}, instruction_address, true) {
-				self.write_csr_raw(CSR_MIP_ADDRESS, self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_SEIP);
+			if self.handle_trap(
+				Trap {
+					trap_type: TrapType::SupervisorExternalInterrupt,
+					value: self.pc, // dummy
+				},
+				instruction_address,
+				true,
+			) {
+				self.write_csr_raw(
+					CSR_MIP_ADDRESS,
+					self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_SEIP,
+				);
 				self.wfi = false;
 				return;
 			}
 		}
 		if (minterrupt & MIP_SSIP) != 0 {
-			if self.handle_trap(Trap {
-				trap_type: TrapType::SupervisorSoftwareInterrupt,
-				value: self.pc // dummy
-			}, instruction_address, true) {
-				self.write_csr_raw(CSR_MIP_ADDRESS, self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_SSIP);
+			if self.handle_trap(
+				Trap {
+					trap_type: TrapType::SupervisorSoftwareInterrupt,
+					value: self.pc, // dummy
+				},
+				instruction_address,
+				true,
+			) {
+				self.write_csr_raw(
+					CSR_MIP_ADDRESS,
+					self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_SSIP,
+				);
 				self.wfi = false;
 				return;
 			}
 		}
 		if (minterrupt & MIP_STIP) != 0 {
-			if self.handle_trap(Trap {
-				trap_type: TrapType::SupervisorTimerInterrupt,
-				value: self.pc // dummy
-			}, instruction_address, true) {
-				self.write_csr_raw(CSR_MIP_ADDRESS, self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_STIP);
+			if self.handle_trap(
+				Trap {
+					trap_type: TrapType::SupervisorTimerInterrupt,
+					value: self.pc, // dummy
+				},
+				instruction_address,
+				true,
+			) {
+				self.write_csr_raw(
+					CSR_MIP_ADDRESS,
+					self.read_csr_raw(CSR_MIP_ADDRESS) & !MIP_STIP,
+				);
 				self.wfi = false;
 				return;
 			}
@@ -447,7 +490,7 @@ impl Cpu {
 		self.handle_trap(exception, instruction_address, false);
 	}
 
-	fn handle_trap(&mut self, trap: Trap, instruction_address: u64, is_interrupt: bool) -> bool{
+	fn handle_trap(&mut self, trap: Trap, instruction_address: u64, is_interrupt: bool) -> bool {
 		let current_privilege_encoding = get_privilege_encoding(&self.privilege_mode) as u64;
 		let cause = get_trap_cause(&trap, &self.xlen);
 
@@ -455,11 +498,11 @@ impl Cpu {
 		// @TODO: Check if this logic is correct
 		let mdeleg = match is_interrupt {
 			true => self.read_csr_raw(CSR_MIDELEG_ADDRESS),
-			false => self.read_csr_raw(CSR_MEDELEG_ADDRESS)
+			false => self.read_csr_raw(CSR_MEDELEG_ADDRESS),
 		};
 		let sdeleg = match is_interrupt {
 			true => self.read_csr_raw(CSR_SIDELEG_ADDRESS),
-			false => self.read_csr_raw(CSR_SEDELEG_ADDRESS)
+			false => self.read_csr_raw(CSR_SEDELEG_ADDRESS),
 		};
 		let pos = cause & 0xffff;
 
@@ -467,8 +510,8 @@ impl Cpu {
 			true => PrivilegeMode::Machine,
 			false => match ((sdeleg >> pos) & 1) == 0 {
 				true => PrivilegeMode::Supervisor,
-				false => PrivilegeMode::User
-			}
+				false => PrivilegeMode::User,
+			},
 		};
 		let new_privilege_encoding = get_privilege_encoding(&new_privilege_mode) as u64;
 
@@ -520,18 +563,18 @@ impl Cpu {
 						if current_mie == 0 {
 							return false;
 						}
-					},
+					}
 					PrivilegeMode::Supervisor => {
 						if current_sie == 0 {
 							return false;
 						}
-					},
+					}
 					PrivilegeMode::User => {
 						if current_uie == 0 {
 							return false;
 						}
-					},
-					PrivilegeMode::Reserved => panic!()
+					}
+					PrivilegeMode::Reserved => panic!(),
 				};
 			}
 
@@ -543,47 +586,47 @@ impl Cpu {
 					if usie == 0 {
 						return false;
 					}
-				},
+				}
 				TrapType::SupervisorSoftwareInterrupt => {
 					if ssie == 0 {
 						return false;
 					}
-				},
+				}
 				TrapType::MachineSoftwareInterrupt => {
 					if msie == 0 {
 						return false;
 					}
-				},
+				}
 				TrapType::UserTimerInterrupt => {
 					if utie == 0 {
 						return false;
 					}
-				},
+				}
 				TrapType::SupervisorTimerInterrupt => {
 					if stie == 0 {
 						return false;
 					}
-				},
+				}
 				TrapType::MachineTimerInterrupt => {
 					if mtie == 0 {
 						return false;
 					}
-				},
+				}
 				TrapType::UserExternalInterrupt => {
 					if ueie == 0 {
 						return false;
 					}
-				},
+				}
 				TrapType::SupervisorExternalInterrupt => {
 					if seie == 0 {
 						return false;
 					}
-				},
+				}
 				TrapType::MachineExternalInterrupt => {
 					if meie == 0 {
 						return false;
 					}
-				},
+				}
 				_ => {}
 			};
 		}
@@ -596,25 +639,25 @@ impl Cpu {
 			PrivilegeMode::Machine => CSR_MEPC_ADDRESS,
 			PrivilegeMode::Supervisor => CSR_SEPC_ADDRESS,
 			PrivilegeMode::User => CSR_UEPC_ADDRESS,
-			PrivilegeMode::Reserved => panic!()
+			PrivilegeMode::Reserved => panic!(),
 		};
 		let csr_cause_address = match self.privilege_mode {
 			PrivilegeMode::Machine => CSR_MCAUSE_ADDRESS,
 			PrivilegeMode::Supervisor => CSR_SCAUSE_ADDRESS,
 			PrivilegeMode::User => CSR_UCAUSE_ADDRESS,
-			PrivilegeMode::Reserved => panic!()
+			PrivilegeMode::Reserved => panic!(),
 		};
 		let csr_tval_address = match self.privilege_mode {
 			PrivilegeMode::Machine => CSR_MTVAL_ADDRESS,
 			PrivilegeMode::Supervisor => CSR_STVAL_ADDRESS,
 			PrivilegeMode::User => CSR_UTVAL_ADDRESS,
-			PrivilegeMode::Reserved => panic!()
+			PrivilegeMode::Reserved => panic!(),
 		};
 		let csr_tvec_address = match self.privilege_mode {
 			PrivilegeMode::Machine => CSR_MTVEC_ADDRESS,
 			PrivilegeMode::Supervisor => CSR_STVEC_ADDRESS,
 			PrivilegeMode::User => CSR_UTVEC_ADDRESS,
-			PrivilegeMode::Reserved => panic!()
+			PrivilegeMode::Reserved => panic!(),
 		};
 
 		self.write_csr_raw(csr_epc_address, instruction_address);
@@ -632,20 +675,22 @@ impl Cpu {
 				let status = self.read_csr_raw(CSR_MSTATUS_ADDRESS);
 				let mie = (status >> 3) & 1;
 				// clear MIE[3], override MPIE[7] with MIE[3], override MPP[12:11] with current privilege encoding
-				let new_status = (status & !0x1888) | (mie << 7) | (current_privilege_encoding << 11);
+				let new_status =
+					(status & !0x1888) | (mie << 7) | (current_privilege_encoding << 11);
 				self.write_csr_raw(CSR_MSTATUS_ADDRESS, new_status);
-			},
+			}
 			PrivilegeMode::Supervisor => {
 				let status = self.read_csr_raw(CSR_SSTATUS_ADDRESS);
 				let sie = (status >> 1) & 1;
 				// clear SIE[1], override SPIE[5] with SIE[1], override SPP[8] with current privilege encoding
-				let new_status = (status & !0x122) | (sie << 5) | ((current_privilege_encoding & 1) << 8);
+				let new_status =
+					(status & !0x122) | (sie << 5) | ((current_privilege_encoding & 1) << 8);
 				self.write_csr_raw(CSR_SSTATUS_ADDRESS, new_status);
-			},
+			}
 			PrivilegeMode::User => {
 				panic!("Not implemented yet");
-			},
-			PrivilegeMode::Reserved => panic!() // shouldn't happen
+			}
+			PrivilegeMode::Reserved => panic!(), // shouldn't happen
 		};
 		//println!("Trap! {:x} Clock:{:x}", cause, self.clock);
 		true
@@ -672,8 +717,8 @@ impl Cpu {
 			true => Ok(self.read_csr_raw(address)),
 			false => Err(Trap {
 				trap_type: TrapType::IllegalInstruction,
-				value: self.pc.wrapping_sub(4) // @TODO: Is this always correct?
-			})
+				value: self.pc.wrapping_sub(4), // @TODO: Is this always correct?
+			}),
 		}
 	}
 
@@ -692,11 +737,11 @@ impl Cpu {
 					self.update_addressing_mode(value);
 				}
 				Ok(())
-			},
+			}
 			false => Err(Trap {
 				trap_type: TrapType::IllegalInstruction,
-				value: self.pc.wrapping_sub(4) // @TODO: Is this always correct?
-			})
+				value: self.pc.wrapping_sub(4), // @TODO: Is this always correct?
+			}),
 		}
 	}
 
@@ -710,7 +755,7 @@ impl Cpu {
 			CSR_SIE_ADDRESS => self.csr[CSR_MIE_ADDRESS as usize] & 0x222,
 			CSR_SIP_ADDRESS => self.csr[CSR_MIP_ADDRESS as usize] & 0x222,
 			CSR_TIME_ADDRESS => self.mmu.get_clint().read_mtime(),
-			_ => self.csr[address as usize]
+			_ => self.csr[address as usize],
 		}
 	}
 
@@ -719,34 +764,36 @@ impl Cpu {
 			CSR_FFLAGS_ADDRESS => {
 				self.csr[CSR_FCSR_ADDRESS as usize] &= !0x1f;
 				self.csr[CSR_FCSR_ADDRESS as usize] |= value & 0x1f;
-			},
+			}
 			CSR_FRM_ADDRESS => {
 				self.csr[CSR_FCSR_ADDRESS as usize] &= !0xe0;
 				self.csr[CSR_FCSR_ADDRESS as usize] |= (value << 5) & 0xe0;
-			},
+			}
 			CSR_SSTATUS_ADDRESS => {
 				self.csr[CSR_MSTATUS_ADDRESS as usize] &= !0x80000003000de162;
 				self.csr[CSR_MSTATUS_ADDRESS as usize] |= value & 0x80000003000de162;
-				self.mmu.update_mstatus(self.read_csr_raw(CSR_MSTATUS_ADDRESS));
-			},
+				self.mmu
+					.update_mstatus(self.read_csr_raw(CSR_MSTATUS_ADDRESS));
+			}
 			CSR_SIE_ADDRESS => {
 				self.csr[CSR_MIE_ADDRESS as usize] &= !0x222;
 				self.csr[CSR_MIE_ADDRESS as usize] |= value & 0x222;
-			},
+			}
 			CSR_SIP_ADDRESS => {
 				self.csr[CSR_MIP_ADDRESS as usize] &= !0x222;
 				self.csr[CSR_MIP_ADDRESS as usize] |= value & 0x222;
-			},
+			}
 			CSR_MIDELEG_ADDRESS => {
 				self.csr[address as usize] = value & 0x666; // from qemu
-			},
+			}
 			CSR_MSTATUS_ADDRESS => {
 				self.csr[address as usize] = value;
-				self.mmu.update_mstatus(self.read_csr_raw(CSR_MSTATUS_ADDRESS));
-			},
+				self.mmu
+					.update_mstatus(self.read_csr_raw(CSR_MSTATUS_ADDRESS));
+			}
 			CSR_TIME_ADDRESS => {
 				self.mmu.get_mut_clint().write_mtime(value);
-			},
+			}
 			_ => {
 				self.csr[address as usize] = value;
 			}
@@ -777,7 +824,7 @@ impl Cpu {
 		let addressing_mode = match self.xlen {
 			Xlen::Bit32 => match value & 0x80000000 {
 				0 => AddressingMode::None,
-				_ => AddressingMode::SV32
+				_ => AddressingMode::SV32,
 			},
 			Xlen::Bit64 => match value >> 60 {
 				0 => AddressingMode::None,
@@ -787,11 +834,11 @@ impl Cpu {
 					println!("Unknown addressing_mode {:x}", value >> 60);
 					panic!();
 				}
-			}
+			},
 		};
 		let ppn = match self.xlen {
 			Xlen::Bit32 => value & 0x3fffff,
-			Xlen::Bit64 => value & 0xfffffffffff
+			Xlen::Bit64 => value & 0xfffffffffff,
 		};
 		self.mmu.update_addressing_mode(addressing_mode);
 		self.mmu.update_ppn(ppn);
@@ -801,7 +848,7 @@ impl Cpu {
 	fn sign_extend(&self, value: i64) -> i64 {
 		match self.xlen {
 			Xlen::Bit32 => value as i32 as i64,
-			Xlen::Bit64 => value
+			Xlen::Bit64 => value,
 		}
 	}
 
@@ -814,7 +861,7 @@ impl Cpu {
 	fn most_negative(&self) -> i64 {
 		match self.xlen {
 			Xlen::Bit32 => std::i32::MIN as i64,
-			Xlen::Bit64 => std::i64::MIN
+			Xlen::Bit64 => std::i64::MIN,
 		}
 	}
 
@@ -829,90 +876,95 @@ impl Cpu {
 					// C.ADDI4SPN
 					// addi rd+8, x2, nzuimm
 					let rd = (halfword >> 2) & 0x7; // [4:2]
-					let nzuimm =
-						((halfword >> 7) & 0x30) | // nzuimm[5:4] <= [12:11]
+					let nzuimm = ((halfword >> 7) & 0x30) | // nzuimm[5:4] <= [12:11]
 						((halfword >> 1) & 0x3c0) | // nzuimm{9:6] <= [10:7]
 						((halfword >> 4) & 0x4) | // nzuimm[2] <= [6]
 						((halfword >> 2) & 0x8); // nzuimm[3] <= [5]
-					// nzuimm == 0 is reserved instruction
+							   // nzuimm == 0 is reserved instruction
 					if nzuimm != 0 {
 						return (nzuimm << 20) | (2 << 15) | ((rd + 8) << 7) | 0x13;
 					}
-				},
+				}
 				1 => {
 					// @TODO: Support C.LQ for 128-bit
 					// C.FLD for 32, 64-bit
 					// fld rd+8, offset(rs1+8)
 					let rd = (halfword >> 2) & 0x7; // [4:2]
 					let rs1 = (halfword >> 7) & 0x7; // [9:7]
-					let offset =
-						((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
+					let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
 						((halfword << 1) & 0xc0); // offset[7:6] <= [6:5]
 					return (offset << 20) | ((rs1 + 8) << 15) | (3 << 12) | ((rd + 8) << 7) | 0x7;
-				},
+				}
 				2 => {
 					// C.LW
 					// lw rd+8, offset(rs1+8)
 					let rs1 = (halfword >> 7) & 0x7; // [9:7]
 					let rd = (halfword >> 2) & 0x7; // [4:2]
-					let offset =
-						((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
+					let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
 						((halfword >> 4) & 0x4) | // offset[2] <= [6]
 						((halfword << 1) & 0x40); // offset[6] <= [5]
 					return (offset << 20) | ((rs1 + 8) << 15) | (2 << 12) | ((rd + 8) << 7) | 0x3;
-				},
+				}
 				3 => {
 					// @TODO: Support C.FLW in 32-bit mode
 					// C.LD in 64-bit mode
 					// ld rd+8, offset(rs1+8)
 					let rs1 = (halfword >> 7) & 0x7; // [9:7]
 					let rd = (halfword >> 2) & 0x7; // [4:2]
-					let offset =
-						((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
+					let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
 						((halfword << 1) & 0xc0); // offset[7:6] <= [6:5]
 					return (offset << 20) | ((rs1 + 8) << 15) | (3 << 12) | ((rd + 8) << 7) | 0x3;
-				},
+				}
 				4 => {
 					// Reserved
-				},
+				}
 				5 => {
 					// C.FSD
 					// fsd rs2+8, offset(rs1+8)
 					let rs1 = (halfword >> 7) & 0x7; // [9:7]
 					let rs2 = (halfword >> 2) & 0x7; // [4:2]
-					let offset = 
-						((halfword >> 7) & 0x38) | // uimm[5:3] <= [12:10]
+					let offset = ((halfword >> 7) & 0x38) | // uimm[5:3] <= [12:10]
 						((halfword << 1) & 0xc0); // uimm[7:6] <= [6:5]
 					let imm11_5 = (offset >> 5) & 0x7f;
 					let imm4_0 = offset & 0x1f;
-					return (imm11_5 << 25) | ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | (3 << 12) | (imm4_0 << 7) | 0x27;
-				},
+					return (imm11_5 << 25)
+						| ((rs2 + 8) << 20)
+						| ((rs1 + 8) << 15)
+						| (3 << 12) | (imm4_0 << 7)
+						| 0x27;
+				}
 				6 => {
 					// C.SW
 					// sw rs2+8, offset(rs1+8)
 					let rs1 = (halfword >> 7) & 0x7; // [9:7]
 					let rs2 = (halfword >> 2) & 0x7; // [4:2]
-					let offset = 
-						((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
+					let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
 						((halfword << 1) & 0x40) | // offset[6] <= [5]
 						((halfword >> 4) & 0x4); // offset[2] <= [6]
 					let imm11_5 = (offset >> 5) & 0x7f;
 					let imm4_0 = offset & 0x1f;
-					return (imm11_5 << 25) | ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | (2 << 12) | (imm4_0 << 7) | 0x23;
-				},
+					return (imm11_5 << 25)
+						| ((rs2 + 8) << 20)
+						| ((rs1 + 8) << 15)
+						| (2 << 12) | (imm4_0 << 7)
+						| 0x23;
+				}
 				7 => {
 					// @TODO: Support C.FSW in 32-bit mode
 					// C.SD
 					// sd rs2+8, offset(rs1+8)
 					let rs1 = (halfword >> 7) & 0x7; // [9:7]
 					let rs2 = (halfword >> 2) & 0x7; // [4:2]
-					let offset = 
-						((halfword >> 7) & 0x38) | // uimm[5:3] <= [12:10]
+					let offset = ((halfword >> 7) & 0x38) | // uimm[5:3] <= [12:10]
 						((halfword << 1) & 0xc0); // uimm[7:6] <= [6:5]
 					let imm11_5 = (offset >> 5) & 0x7f;
 					let imm4_0 = offset & 0x1f;
-					return (imm11_5 << 25) | ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | (3 << 12) | (imm4_0 << 7) | 0x23;
-				},
+					return (imm11_5 << 25)
+						| ((rs2 + 8) << 20)
+						| ((rs1 + 8) << 15)
+						| (3 << 12) | (imm4_0 << 7)
+						| 0x23;
+				}
 				_ => {} // Not happens
 			},
 			1 => {
@@ -936,7 +988,7 @@ impl Cpu {
 						}
 						// @TODO: Support HINTs
 						// r == 0 and imm != 0 is HINTs
-					},
+					}
 					1 => {
 						// @TODO: Support C.JAL in 32-bit mode
 						// C.ADDIW
@@ -952,7 +1004,7 @@ impl Cpu {
 							return (imm << 20) | (r << 15) | (r << 7) | 0x1b;
 						}
 						// r == 0 is reserved instruction
-					},
+					}
 					2 => {
 						// C.LI
 						// addi rd, x0, imm
@@ -968,7 +1020,7 @@ impl Cpu {
 						}
 						// @TODO: Support HINTs
 						// r == 0 is for HINTs
-					},
+					}
 					3 => {
 						let r = (halfword >> 7) & 0x1f; // [11:7]
 						if r == 2 {
@@ -1002,28 +1054,31 @@ impl Cpu {
 							}
 							// nzimm == 0 is for reserved instruction
 						}
-					},
+					}
 					4 => {
 						let funct2 = (halfword >> 10) & 0x3; // [11:10]
 						match funct2 {
 							0 => {
 								// C.SRLI
 								// c.srli rs1+8, rs1+8, shamt
-								let shamt = 
-									((halfword >> 7) & 0x20) | // shamt[5] <= [12]
+								let shamt = ((halfword >> 7) & 0x20) | // shamt[5] <= [12]
 									((halfword >> 2) & 0x1f); // shamt[4:0] <= [6:2]
 								let rs1 = (halfword >> 7) & 0x7; // [9:7]
-								return (shamt << 20) | ((rs1 + 8) << 15) | (5 << 12) | ((rs1 + 8) << 7) | 0x13;
-							},
+								return (shamt << 20)
+									| ((rs1 + 8) << 15) | (5 << 12)
+									| ((rs1 + 8) << 7) | 0x13;
+							}
 							1 => {
 								// C.SRAI
 								// srai rs1+8, rs1+8, shamt
-								let shamt = 
-									((halfword >> 7) & 0x20) | // shamt[5] <= [12]
+								let shamt = ((halfword >> 7) & 0x20) | // shamt[5] <= [12]
 									((halfword >> 2) & 0x1f); // shamt[4:0] <= [6:2]
 								let rs1 = (halfword >> 7) & 0x7; // [9:7]
-								return (0x20 << 25) | (shamt << 20) | ((rs1 + 8) << 15) | (5 << 12) | ((rs1 + 8) << 7) | 0x13;
-							},
+								return (0x20 << 25)
+									| (shamt << 20) | ((rs1 + 8) << 15)
+									| (5 << 12) | ((rs1 + 8) << 7)
+									| 0x13;
+							}
 							2 => {
 								// C.ANDI
 								// andi, r+8, r+8, imm
@@ -1034,8 +1089,10 @@ impl Cpu {
 								} | // imm[31:6] <= [12]
 								((halfword >> 7) & 0x20) | // imm[5] <= [12]
 								((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
-								return (imm << 20) | ((r + 8) << 15) | (7 << 12) | ((r + 8) << 7) | 0x13;
-							},
+								return (imm << 20)
+									| ((r + 8) << 15) | (7 << 12)
+									| ((r + 8) << 7) | 0x13;
+							}
 							3 => {
 								let funct1 = (halfword >> 12) & 1; // [12]
 								let funct2_2 = (halfword >> 5) & 0x3; // [6:5]
@@ -1046,55 +1103,66 @@ impl Cpu {
 										0 => {
 											// C.SUB
 											// sub rs1+8, rs1+8, rs2+8
-											return (0x20 << 25) | ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | ((rs1 + 8) << 7) | 0x33;
-										},
+											return (0x20 << 25)
+												| ((rs2 + 8) << 20) | ((rs1 + 8) << 15)
+												| ((rs1 + 8) << 7) | 0x33;
+										}
 										1 => {
 											// C.XOR
 											// xor rs1+8, rs1+8, rs2+8
-											return ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | (4 << 12) | ((rs1 + 8) << 7) | 0x33;
-										},
+											return ((rs2 + 8) << 20)
+												| ((rs1 + 8) << 15) | (4 << 12) | ((rs1 + 8)
+												<< 7) | 0x33;
+										}
 										2 => {
 											// C.OR
 											// or rs1+8, rs1+8, rs2+8
-											return ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | (6 << 12) | ((rs1 + 8) << 7) | 0x33;
-										},
+											return ((rs2 + 8) << 20)
+												| ((rs1 + 8) << 15) | (6 << 12) | ((rs1 + 8)
+												<< 7) | 0x33;
+										}
 										3 => {
 											// C.AND
 											// and rs1+8, rs1+8, rs2+8
-											return ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | (7 << 12) | ((rs1 + 8) << 7) | 0x33;
-										},
+											return ((rs2 + 8) << 20)
+												| ((rs1 + 8) << 15) | (7 << 12) | ((rs1 + 8)
+												<< 7) | 0x33;
+										}
 										_ => {} // Not happens
 									},
 									1 => match funct2_2 {
 										0 => {
 											// C.SUBW
 											// subw r1+8, r1+8, r2+8
-											return (0x20 << 25) | ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | ((rs1 + 8) << 7) | 0x3b;
-										},
+											return (0x20 << 25)
+												| ((rs2 + 8) << 20) | ((rs1 + 8) << 15)
+												| ((rs1 + 8) << 7) | 0x3b;
+										}
 										1 => {
 											// C.ADDW
 											// addw r1+8, r1+8, r2+8
-											return ((rs2 + 8) << 20) | ((rs1 + 8) << 15) | ((rs1 + 8) << 7) | 0x3b;
-										},
+											return ((rs2 + 8) << 20)
+												| ((rs1 + 8) << 15) | ((rs1 + 8) << 7)
+												| 0x3b;
+										}
 										2 => {
 											// Reserved
-										},
+										}
 										3 => {
 											// Reserved
-										},
+										}
 										_ => {} // Not happens
 									},
 									_ => {} // No happens
 								};
-							},
+							}
 							_ => {} // not happens
 						};
-					},
+					}
 					5 => {
 						// C.J
 						// jal x0, imm
-						let offset =
-							match halfword & 0x1000 {
+						let offset = match halfword & 0x1000 {
 								0x1000 => 0xfffff000,
 								_ => 0
 							} | // offset[31:12] <= [12]
@@ -1106,19 +1174,17 @@ impl Cpu {
 							((halfword << 1) & 0x80) | // offset[7] <= [6]
 							((halfword >> 2) & 0xe) | // offset[3:1] <= [5:3]
 							((halfword << 3) & 0x20); // offset[5] <= [2]
-						let imm =
-							((offset >> 1) & 0x80000) | // imm[19] <= offset[20]
+						let imm = ((offset >> 1) & 0x80000) | // imm[19] <= offset[20]
 							((offset << 8) & 0x7fe00) | // imm[18:9] <= offset[10:1]
 							((offset >> 3) & 0x100) | // imm[8] <= offset[11]
 							((offset >> 12) & 0xff); // imm[7:0] <= offset[19:12]
 						return (imm << 12) | 0x6f;
-					},
+					}
 					6 => {
 						// C.BEQZ
 						// beq r+8, x0, offset
 						let r = (halfword >> 7) & 0x7;
-						let offset =
-							match halfword & 0x1000 {
+						let offset = match halfword & 0x1000 {
 								0x1000 => 0xfffffe00,
 								_ => 0
 							} | // offset[31:9] <= [12]
@@ -1127,20 +1193,17 @@ impl Cpu {
 							((halfword << 1) & 0xc0) | // offset[7:6] <= [6:5]
 							((halfword >> 2) & 0x6) | // offset[2:1] <= [4:3]
 							((halfword << 3) & 0x20); // offset[5] <= [2]
-						let imm2 =
-							((offset >> 6) & 0x40) | // imm2[6] <= [12]
+						let imm2 = ((offset >> 6) & 0x40) | // imm2[6] <= [12]
 							((offset >> 5) & 0x3f); // imm2[5:0] <= [10:5]
-						let imm1 =
-							(offset & 0x1e) | // imm1[4:1] <= [4:1]
+						let imm1 = (offset & 0x1e) | // imm1[4:1] <= [4:1]
 							((offset >> 11) & 0x1); // imm1[0] <= [11]
 						return (imm2 << 25) | ((r + 8) << 20) | (imm1 << 7) | 0x63;
-					},
+					}
 					7 => {
 						// C.BNEZ
 						// bne r+8, x0, offset
 						let r = (halfword >> 7) & 0x7;
-						let offset =
-							match halfword & 0x1000 {
+						let offset = match halfword & 0x1000 {
 								0x1000 => 0xfffffe00,
 								_ => 0
 							} | // offset[31:9] <= [12]
@@ -1149,71 +1212,65 @@ impl Cpu {
 							((halfword << 1) & 0xc0) | // offset[7:6] <= [6:5]
 							((halfword >> 2) & 0x6) | // offset[2:1] <= [4:3]
 							((halfword << 3) & 0x20); // offset[5] <= [2]
-						let imm2 =
-							((offset >> 6) & 0x40) | // imm2[6] <= [12]
+						let imm2 = ((offset >> 6) & 0x40) | // imm2[6] <= [12]
 							((offset >> 5) & 0x3f); // imm2[5:0] <= [10:5]
-						let imm1 =
-							(offset & 0x1e) | // imm1[4:1] <= [4:1]
+						let imm1 = (offset & 0x1e) | // imm1[4:1] <= [4:1]
 							((offset >> 11) & 0x1); // imm1[0] <= [11]
 						return (imm2 << 25) | ((r + 8) << 20) | (1 << 12) | (imm1 << 7) | 0x63;
-					},
+					}
 					_ => {} // No happens
 				};
-			},
+			}
 			2 => {
 				match funct3 {
 					0 => {
 						// C.SLLI
 						// slli r, r, shamt
 						let r = (halfword >> 7) & 0x1f;
-						let shamt =
-							((halfword >> 7) & 0x20) | // imm[5] <= [12]
+						let shamt = ((halfword >> 7) & 0x20) | // imm[5] <= [12]
 							((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
 						if r != 0 {
 							return (shamt << 20) | (r << 15) | (1 << 12) | (r << 7) | 0x13;
 						}
 						// r == 0 is reserved instruction?
-					},
+					}
 					1 => {
 						// C.FLDSP
 						// fld rd, offset(x2)
 						let rd = (halfword >> 7) & 0x1f;
-						let offset =
-							((halfword >> 7) & 0x20) | // offset[5] <= [12]
+						let offset = ((halfword >> 7) & 0x20) | // offset[5] <= [12]
 							((halfword >> 2) & 0x18) | // offset[4:3] <= [6:5]
 							((halfword << 4) & 0x1c0); // offset[8:6] <= [4:2]
 						if rd != 0 {
 							return (offset << 20) | (2 << 15) | (3 << 12) | (rd << 7) | 0x7;
 						}
 						// rd == 0 is reseved instruction
-					},
+					}
 					2 => {
 						// C.LWSP
 						// lw r, offset(x2)
 						let r = (halfword >> 7) & 0x1f;
-						let offset =
-							((halfword >> 7) & 0x20) | // offset[5] <= [12]
+						let offset = ((halfword >> 7) & 0x20) | // offset[5] <= [12]
 							((halfword >> 2) & 0x1c) | // offset[4:2] <= [6:4]
 							((halfword << 4) & 0xc0); // offset[7:6] <= [3:2]
 						if r != 0 {
 							return (offset << 20) | (2 << 15) | (2 << 12) | (r << 7) | 0x3;
 						}
 						// r == 0 is reseved instruction
-					},
+					}
 					3 => {
 						// @TODO: Support C.FLWSP in 32-bit mode
 						// C.LDSP
 						// ld rd, offset(x2)
 						let rd = (halfword >> 7) & 0x1f;
-						let offset =
-							((halfword >> 7) & 0x20) | // offset[5] <= [12]
+						let offset = ((halfword >> 7) & 0x20) | // offset[5] <= [12]
 							((halfword >> 2) & 0x18) | // offset[4:3] <= [6:5]
 							((halfword << 4) & 0x1c0); // offset[8:6] <= [4:2]
 						if rd != 0 {
 							return (offset << 20) | (2 << 15) | (3 << 12) | (rd << 7) | 0x3;
 						}
 						// rd == 0 is reseved instruction
-					},
+					}
 					4 => {
 						let funct1 = (halfword >> 12) & 1; // [12]
 						let rs1 = (halfword >> 7) & 0x1f; // [11:7]
@@ -1234,7 +1291,7 @@ impl Cpu {
 								}
 								// rs1 == 0 && rs2 != 0 is Hints
 								// @TODO: Support Hints
-							},
+							}
 							1 => {
 								if rs1 == 0 && rs2 == 0 {
 									// C.EBREAK
@@ -1253,48 +1310,54 @@ impl Cpu {
 								}
 								// rs1 == 0 && rs2 != 0 is Hists
 								// @TODO: Supports Hinsts
-							},
+							}
 							_ => {} // Not happens
 						};
-					},
+					}
 					5 => {
 						// @TODO: Implement
 						// C.FSDSP
 						// fsd rs2, offset(x2)
 						let rs2 = (halfword >> 2) & 0x1f; // [6:2]
-						let offset =
-							((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
+						let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
 							((halfword >> 1) & 0x1c0); // offset[8:6] <= [9:7]
 						let imm11_5 = (offset >> 5) & 0x3f;
 						let imm4_0 = offset & 0x1f;
-						return (imm11_5 << 25) | (rs2 << 20) | (2 << 15) | (3 << 12) | (imm4_0 << 7) | 0x27;
-					},
+						return (imm11_5 << 25)
+							| (rs2 << 20) | (2 << 15)
+							| (3 << 12) | (imm4_0 << 7)
+							| 0x27;
+					}
 					6 => {
 						// C.SWSP
 						// sw rs2, offset(x2)
 						let rs2 = (halfword >> 2) & 0x1f; // [6:2]
-						let offset =
-							((halfword >> 7) & 0x3c) | // offset[5:2] <= [12:9]
+						let offset = ((halfword >> 7) & 0x3c) | // offset[5:2] <= [12:9]
 							((halfword >> 1) & 0xc0); // offset[7:6] <= [8:7]
 						let imm11_5 = (offset >> 5) & 0x3f;
 						let imm4_0 = offset & 0x1f;
-						return (imm11_5 << 25) | (rs2 << 20) | (2 << 15) | (2 << 12) | (imm4_0 << 7) | 0x23;
-					},
+						return (imm11_5 << 25)
+							| (rs2 << 20) | (2 << 15)
+							| (2 << 12) | (imm4_0 << 7)
+							| 0x23;
+					}
 					7 => {
 						// @TODO: Support C.FSWSP in 32-bit mode
 						// C.SDSP
 						// sd rs, offset(x2)
 						let rs2 = (halfword >> 2) & 0x1f; // [6:2]
-						let offset =
-							((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
+						let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
 							((halfword >> 1) & 0x1c0); // offset[8:6] <= [9:7]
 						let imm11_5 = (offset >> 5) & 0x3f;
 						let imm4_0 = offset & 0x1f;
-						return (imm11_5 << 25) | (rs2 << 20) | (2 << 15) | (3 << 12) | (imm4_0 << 7) | 0x23;
-					},
+						return (imm11_5 << 25)
+							| (rs2 << 20) | (2 << 15)
+							| (3 << 12) | (imm4_0 << 7)
+							| 0x23;
+					}
 					_ => {} // Not happens
 				};
-			},
+			}
 			_ => {} // No happnes
 		};
 		0xffffffff // Return invalid value
@@ -1321,12 +1384,17 @@ impl Cpu {
 			}
 		};
 
-		let inst = {match self.decode_raw(word) {
-			Ok(inst) => inst,
-			Err(()) => {
-				return format!("Unknown instruction PC:{:x} WORD:{:x}", self.pc, original_word);
+		let inst = {
+			match self.decode_raw(word) {
+				Ok(inst) => inst,
+				Err(()) => {
+					return format!(
+						"Unknown instruction PC:{:x} WORD:{:x}",
+						self.pc, original_word
+					);
+				}
 			}
-		}};
+		};
 
 		let mut s = format!("PC:{:016x} ", self.unsigned_data(self.pc as i64));
 		s += &format!("{:08x} ", original_word);
@@ -1351,13 +1419,13 @@ struct Instruction {
 	data: u32, // @TODO: rename
 	name: &'static str,
 	operation: fn(cpu: &mut Cpu, word: u32, address: u64) -> Result<(), Trap>,
-	disassemble: fn(cpu: &mut Cpu, word: u32, address: u64, evaluate: bool) -> String
+	disassemble: fn(cpu: &mut Cpu, word: u32, address: u64, evaluate: bool) -> String,
 }
 
 struct FormatB {
 	rs1: usize,
 	rs2: usize,
-	imm: u64
+	imm: u64,
 }
 
 fn parse_format_b(word: u32) -> FormatB {
@@ -1371,8 +1439,9 @@ fn parse_format_b(word: u32) -> FormatB {
 			} |
 			((word << 4) & 0x00000800) | // imm[11] = [7]
 			((word >> 20) & 0x000007e0) | // imm[10:5] = [30:25]
-			((word >> 7) & 0x0000001e) // imm[4:1] = [11:8]
-		) as i32 as i64 as u64
+			((word >> 7) & 0x0000001e)
+			// imm[4:1] = [11:8]
+		) as i32 as i64 as u64,
 	}
 }
 
@@ -1394,14 +1463,14 @@ fn dump_format_b(cpu: &mut Cpu, word: u32, address: u64, evaluate: bool) -> Stri
 struct FormatCSR {
 	csr: u16,
 	rs: usize,
-	rd: usize
+	rd: usize,
 }
 
 fn parse_format_csr(word: u32) -> FormatCSR {
 	FormatCSR {
 		csr: ((word >> 20) & 0xfff) as u16, // [31:20]
 		rs: ((word >> 15) & 0x1f) as usize, // [19:15], also uimm
-		rd: ((word >> 7) & 0x1f) as usize // [11:7]
+		rd: ((word >> 7) & 0x1f) as usize,  // [11:7]
 	}
 }
 
@@ -1427,20 +1496,21 @@ fn dump_format_csr(cpu: &mut Cpu, word: u32, _address: u64, evaluate: bool) -> S
 struct FormatI {
 	rd: usize,
 	rs1: usize,
-	imm: i64
+	imm: i64,
 }
 
 fn parse_format_i(word: u32) -> FormatI {
 	FormatI {
-		rd: ((word >> 7) & 0x1f) as usize, // [11:7]
+		rd: ((word >> 7) & 0x1f) as usize,   // [11:7]
 		rs1: ((word >> 15) & 0x1f) as usize, // [19:15]
 		imm: (
-			match word & 0x80000000 { // imm[31:11] = [31]
+			match word & 0x80000000 {
+				// imm[31:11] = [31]
 				0x80000000 => 0xfffff800,
-				_ => 0
-			} |
-			((word >> 20) & 0x000007ff) // imm[10:0] = [30:20]
-		) as i32 as i64
+				_ => 0,
+			} | ((word >> 20) & 0x000007ff)
+			// imm[10:0] = [30:20]
+		) as i32 as i64,
 	}
 }
 
@@ -1476,7 +1546,7 @@ fn dump_format_i_mem(cpu: &mut Cpu, word: u32, _address: u64, evaluate: bool) ->
 
 struct FormatJ {
 	rd: usize,
-	imm: u64
+	imm: u64,
 }
 
 fn parse_format_j(word: u32) -> FormatJ {
@@ -1489,8 +1559,9 @@ fn parse_format_j(word: u32) -> FormatJ {
 			} |
 			(word & 0x000ff000) | // imm[19:12] = [19:12]
 			((word & 0x00100000) >> 9) | // imm[11] = [20]
-			((word & 0x7fe00000) >> 20) // imm[10:1] = [30:21]
-		) as i32 as i64 as u64
+			((word & 0x7fe00000) >> 20)
+			// imm[10:1] = [30:21]
+		) as i32 as i64 as u64,
 	}
 }
 
@@ -1508,14 +1579,14 @@ fn dump_format_j(cpu: &mut Cpu, word: u32, address: u64, evaluate: bool) -> Stri
 struct FormatR {
 	rd: usize,
 	rs1: usize,
-	rs2: usize
+	rs2: usize,
 }
 
 fn parse_format_r(word: u32) -> FormatR {
 	FormatR {
-		rd: ((word >> 7) & 0x1f) as usize, // [11:7]
+		rd: ((word >> 7) & 0x1f) as usize,   // [11:7]
 		rs1: ((word >> 15) & 0x1f) as usize, // [19:15]
-		rs2: ((word >> 20) & 0x1f) as usize // [24:20]
+		rs2: ((word >> 20) & 0x1f) as usize, // [24:20]
 	}
 }
 
@@ -1542,15 +1613,15 @@ struct FormatR2 {
 	rd: usize,
 	rs1: usize,
 	rs2: usize,
-	rs3: usize
+	rs3: usize,
 }
 
 fn parse_format_r2(word: u32) -> FormatR2 {
 	FormatR2 {
-		rd: ((word >> 7) & 0x1f) as usize, // [11:7]
+		rd: ((word >> 7) & 0x1f) as usize,   // [11:7]
 		rs1: ((word >> 15) & 0x1f) as usize, // [19:15]
 		rs2: ((word >> 20) & 0x1f) as usize, // [24:20]
-		rs3: ((word >> 27) & 0x1f) as usize // [31:27]
+		rs3: ((word >> 27) & 0x1f) as usize, // [31:27]
 	}
 }
 
@@ -1579,7 +1650,7 @@ fn dump_format_r2(cpu: &mut Cpu, word: u32, _address: u64, evaluate: bool) -> St
 struct FormatS {
 	rs1: usize,
 	rs2: usize,
-	imm: i64
+	imm: i64,
 }
 
 fn parse_format_s(word: u32) -> FormatS {
@@ -1592,8 +1663,9 @@ fn parse_format_s(word: u32) -> FormatS {
 				_ => 0
 			} | // imm[31:12] = [31]
 			((word >> 20) & 0xfe0) | // imm[11:5] = [31:25]
-			((word >> 7) & 0x1f) // imm[4:0] = [11:7]
-		) as i32 as i64
+			((word >> 7) & 0x1f)
+			// imm[4:0] = [11:7]
+		) as i32 as i64,
 	}
 }
 
@@ -1614,7 +1686,7 @@ fn dump_format_s(cpu: &mut Cpu, word: u32, _address: u64, evaluate: bool) -> Str
 
 struct FormatU {
 	rd: usize,
-	imm: u64
+	imm: u64,
 }
 
 fn parse_format_u(word: u32) -> FormatU {
@@ -1625,8 +1697,9 @@ fn parse_format_u(word: u32) -> FormatU {
 				0x80000000 => 0xffffffff00000000,
 				_ => 0
 			} | // imm[63:32] = [31]
-			((word as u64) & 0xfffff000) // imm[31:12] = [31:12]
-		) as u64
+			((word as u64) & 0xfffff000)
+			// imm[31:12] = [31:12]
+		) as u64,
 	}
 }
 
@@ -1679,13 +1752,13 @@ fn get_register_name(num: usize) -> &'static str {
 		29 => "t4",
 		30 => "t5",
 		31 => "t6",
-		_ => panic!("Unknown register num {}", num)
+		_ => panic!("Unknown register num {}", num),
 	}
 }
 
 const INSTRUCTION_NUM: usize = 116;
 
-// @TODO: Reorder in often used order as 
+// @TODO: Reorder in often used order as
 const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 	Instruction {
 		mask: 0xfe00707f,
@@ -1696,7 +1769,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_add(cpu.x[f.rs2]));
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -1707,7 +1780,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_add(f.imm));
 			Ok(())
 		},
-		disassemble: dump_format_i
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -1718,7 +1791,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.x[f.rs1].wrapping_add(f.imm) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_i
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -1729,7 +1802,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.x[f.rs1].wrapping_add(cpu.x[f.rs2]) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1739,16 +1812,19 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_doubleword(cpu.x[f.rs1] as u64) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
-			match cpu.mmu.store_doubleword(cpu.x[f.rs1] as u64, cpu.x[f.rs2].wrapping_add(tmp) as u64) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+			match cpu
+				.mmu
+				.store_doubleword(cpu.x[f.rs1] as u64, cpu.x[f.rs2].wrapping_add(tmp) as u64)
+			{
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1758,16 +1834,19 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_word(cpu.x[f.rs1] as u64) {
 				Ok(data) => data as i32 as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
-			match cpu.mmu.store_word(cpu.x[f.rs1] as u64, cpu.x[f.rs2].wrapping_add(tmp) as u32) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+			match cpu
+				.mmu
+				.store_word(cpu.x[f.rs1] as u64, cpu.x[f.rs2].wrapping_add(tmp) as u32)
+			{
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1777,16 +1856,19 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_doubleword(cpu.x[f.rs1] as u64) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
-			match cpu.mmu.store_doubleword(cpu.x[f.rs1] as u64, (cpu.x[f.rs2] & tmp) as u64) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+			match cpu
+				.mmu
+				.store_doubleword(cpu.x[f.rs1] as u64, (cpu.x[f.rs2] & tmp) as u64)
+			{
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1796,16 +1878,19 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_word(cpu.x[f.rs1] as u64) {
 				Ok(data) => data as i32 as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
-			match cpu.mmu.store_word(cpu.x[f.rs1] as u64, (cpu.x[f.rs2] & tmp) as u32) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+			match cpu
+				.mmu
+				.store_word(cpu.x[f.rs1] as u64, (cpu.x[f.rs2] & tmp) as u32)
+			{
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1815,20 +1900,20 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_doubleword(cpu.x[f.rs1] as u64) {
 				Ok(data) => data,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			let max = match cpu.x[f.rs2] as u64 >= tmp {
 				true => cpu.x[f.rs2] as u64,
-				false => tmp
+				false => tmp,
 			};
 			match cpu.mmu.store_doubleword(cpu.x[f.rs1] as u64, max) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1838,20 +1923,20 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_word(cpu.x[f.rs1] as u64) {
 				Ok(data) => data,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			let max = match cpu.x[f.rs2] as u32 >= tmp {
 				true => cpu.x[f.rs2] as u32,
-				false => tmp
+				false => tmp,
 			};
 			match cpu.mmu.store_word(cpu.x[f.rs1] as u64, max) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1861,16 +1946,19 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_doubleword(cpu.x[f.rs1] as u64) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
-			match cpu.mmu.store_doubleword(cpu.x[f.rs1] as u64, (cpu.x[f.rs2] | tmp) as u64) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+			match cpu
+				.mmu
+				.store_doubleword(cpu.x[f.rs1] as u64, (cpu.x[f.rs2] | tmp) as u64)
+			{
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1880,16 +1968,19 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_word(cpu.x[f.rs1] as u64) {
 				Ok(data) => data as i32 as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
-			match cpu.mmu.store_word(cpu.x[f.rs1] as u64, (cpu.x[f.rs2] | tmp) as u32) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+			match cpu
+				.mmu
+				.store_word(cpu.x[f.rs1] as u64, (cpu.x[f.rs2] | tmp) as u32)
+			{
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1899,16 +1990,19 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_doubleword(cpu.x[f.rs1] as u64) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
-			match cpu.mmu.store_doubleword(cpu.x[f.rs1] as u64, cpu.x[f.rs2] as u64) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+			match cpu
+				.mmu
+				.store_doubleword(cpu.x[f.rs1] as u64, cpu.x[f.rs2] as u64)
+			{
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -1918,16 +2012,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let tmp = match cpu.mmu.load_word(cpu.x[f.rs1] as u64) {
 				Ok(data) => data as i32 as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			match cpu.mmu.store_word(cpu.x[f.rs1] as u64, cpu.x[f.rs2] as u32) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = tmp;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -1938,7 +2032,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] & cpu.x[f.rs2]);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -1949,7 +2043,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] & f.imm);
 			Ok(())
 		},
-		disassemble: dump_format_i
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0x0000007f,
@@ -1960,7 +2054,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(address.wrapping_add(f.imm) as i64);
 			Ok(())
 		},
-		disassemble: dump_format_u
+		disassemble: dump_format_u,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -1973,7 +2067,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_b
+		disassemble: dump_format_b,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -1986,7 +2080,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_b
+		disassemble: dump_format_b,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -1999,7 +2093,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_b
+		disassemble: dump_format_b,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2012,7 +2106,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_b
+		disassemble: dump_format_b,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2025,7 +2119,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_b
+		disassemble: dump_format_b,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2038,7 +2132,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_b
+		disassemble: dump_format_b,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2048,17 +2142,17 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_csr(word);
 			let data = match cpu.read_csr(f.csr) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			let tmp = cpu.x[f.rs];
 			cpu.x[f.rd] = cpu.sign_extend(data);
 			match cpu.write_csr(f.csr, (cpu.x[f.rd] & !tmp) as u64) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_csr
+		disassemble: dump_format_csr,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2068,16 +2162,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_csr(word);
 			let data = match cpu.read_csr(f.csr) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = cpu.sign_extend(data);
 			match cpu.write_csr(f.csr, (cpu.x[f.rd] & !(f.rs as i64)) as u64) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_csr
+		disassemble: dump_format_csr,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2087,17 +2181,17 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_csr(word);
 			let data = match cpu.read_csr(f.csr) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			let tmp = cpu.x[f.rs];
 			cpu.x[f.rd] = cpu.sign_extend(data);
 			match cpu.write_csr(f.csr, cpu.unsigned_data(cpu.x[f.rd] | tmp)) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_csr
+		disassemble: dump_format_csr,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2107,16 +2201,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_csr(word);
 			let data = match cpu.read_csr(f.csr) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = cpu.sign_extend(data);
 			match cpu.write_csr(f.csr, cpu.unsigned_data(cpu.x[f.rd] | (f.rs as i64))) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_csr
+		disassemble: dump_format_csr,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2126,17 +2220,17 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_csr(word);
 			let data = match cpu.read_csr(f.csr) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			let tmp = cpu.x[f.rs];
 			cpu.x[f.rd] = cpu.sign_extend(data);
 			match cpu.write_csr(f.csr, cpu.unsigned_data(tmp)) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_csr
+		disassemble: dump_format_csr,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2146,16 +2240,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_csr(word);
 			let data = match cpu.read_csr(f.csr) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			cpu.x[f.rd] = cpu.sign_extend(data);
 			match cpu.write_csr(f.csr, f.rs as u64) {
-				Ok(()) => {},
-				Err(e) => return Err(e)
+				Ok(()) => {}
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_csr
+		disassemble: dump_format_csr,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2174,7 +2268,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2191,7 +2285,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2208,7 +2302,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2227,7 +2321,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xffffffff,
@@ -2237,7 +2331,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			// @TODO: Implement
 			Ok(())
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0xffffffff,
@@ -2248,14 +2342,14 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 				PrivilegeMode::User => TrapType::EnvironmentCallFromUMode,
 				PrivilegeMode::Supervisor => TrapType::EnvironmentCallFromSMode,
 				PrivilegeMode::Machine => TrapType::EnvironmentCallFromMMode,
-				PrivilegeMode::Reserved => panic!("Unknown Privilege mode")
+				PrivilegeMode::Reserved => panic!("Unknown Privilege mode"),
 			};
 			return Err(Trap {
 				trap_type: exception_type,
-				value: address
+				value: address,
 			});
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0xfe00007f,
@@ -2266,7 +2360,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = cpu.f[f.rs1] + cpu.f[f.rs2];
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0007f,
@@ -2277,7 +2371,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = cpu.x[f.rs1] as f64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0007f,
@@ -2289,7 +2383,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = f32::from_bits(cpu.f[f.rs1].to_bits() as u32) as f64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0007f,
@@ -2300,7 +2394,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = cpu.x[f.rs1] as i32 as f64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0007f,
@@ -2311,7 +2405,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = cpu.x[f.rs1] as u32 as f64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0007f,
@@ -2323,7 +2417,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = cpu.f[f.rs1] as f32 as f64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0007f,
@@ -2335,7 +2429,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.f[f.rs1] as u32 as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00007f,
@@ -2357,7 +2451,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2367,7 +2461,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			// Do nothing?
 			Ok(())
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2377,7 +2471,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			// Do nothing?
 			Ok(())
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2387,11 +2481,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			cpu.x[f.rd] = match cpu.f[f.rs1] == cpu.f[f.rs2] {
 				true => 1,
-				false => 0
+				false => 0,
 			};
 			Ok(())
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2399,13 +2493,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "FLD",
 		operation: |cpu, word, _address| {
 			let f = parse_format_i(word);
-			cpu.f[f.rd] = match cpu.mmu.load_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
+			cpu.f[f.rd] = match cpu
+				.mmu
+				.load_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64)
+			{
 				Ok(data) => f64::from_bits(data),
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2415,11 +2512,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			cpu.x[f.rd] = match cpu.f[f.rs1] <= cpu.f[f.rs2] {
 				true => 1,
-				false => 0
+				false => 0,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2429,11 +2526,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			cpu.x[f.rd] = match cpu.f[f.rs1] < cpu.f[f.rs2] {
 				true => 1,
-				false => 0
+				false => 0,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2443,11 +2540,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_i(word);
 			cpu.f[f.rd] = match cpu.mmu.load_word(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
 				Ok(data) => f64::from_bits(data as i32 as i64 as u64),
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i_mem
+		disassemble: dump_format_i_mem,
 	},
 	Instruction {
 		mask: 0x0600007f,
@@ -2459,7 +2556,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = cpu.f[f.rs1] * cpu.f[f.rs2] + cpu.f[f.rs3];
 			Ok(())
 		},
-		disassemble: dump_format_r2
+		disassemble: dump_format_r2,
 	},
 	Instruction {
 		mask: 0xfe00007f,
@@ -2471,7 +2568,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = cpu.f[f.rs1] * cpu.f[f.rs2];
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0707f,
@@ -2482,7 +2579,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = f64::from_bits(cpu.x[f.rs1] as u64);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0707f,
@@ -2493,7 +2590,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.f[f.rs1].to_bits() as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0707f,
@@ -2504,7 +2601,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.f[f.rs1].to_bits() as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfff0707f,
@@ -2515,7 +2612,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = f64::from_bits(cpu.x[f.rs1] as u32 as u64);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0600007f,
@@ -2526,7 +2623,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = -(cpu.f[f.rs1] * cpu.f[f.rs2]) + cpu.f[f.rs3];
 			Ok(())
 		},
-		disassemble: dump_format_r2
+		disassemble: dump_format_r2,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2534,9 +2631,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "FSD",
 		operation: |cpu, word, _address| {
 			let f = parse_format_s(word);
-			cpu.mmu.store_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.f[f.rs2].to_bits())
+			cpu.mmu.store_doubleword(
+				cpu.x[f.rs1].wrapping_add(f.imm) as u64,
+				cpu.f[f.rs2].to_bits(),
+			)
 		},
-		disassemble: dump_format_s
+		disassemble: dump_format_s,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2550,7 +2650,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = f64::from_bits(sign_bit | (rs1_bits & 0x7fffffffffffffff));
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2564,7 +2664,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = f64::from_bits(sign_bit | (rs1_bits & 0x7fffffffffffffff));
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00007f,
@@ -2576,7 +2676,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.f[f.rd] = cpu.f[f.rs1] - cpu.f[f.rs2];
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2584,9 +2684,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "FSW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_s(word);
-			cpu.mmu.store_word(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.f[f.rs2].to_bits() as u32)
+			cpu.mmu.store_word(
+				cpu.x[f.rs1].wrapping_add(f.imm) as u64,
+				cpu.f[f.rs2].to_bits() as u32,
+			)
 		},
-		disassemble: dump_format_s
+		disassemble: dump_format_s,
 	},
 	Instruction {
 		mask: 0x0000007f,
@@ -2598,7 +2701,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.pc = address.wrapping_add(f.imm);
 			Ok(())
 		},
-		disassemble: dump_format_j
+		disassemble: dump_format_j,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2624,7 +2727,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			s += &format!(")");
 			s
-		}
+		},
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2634,11 +2737,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_i(word);
 			cpu.x[f.rd] = match cpu.mmu.load(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
 				Ok(data) => data as i8 as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i_mem
+		disassemble: dump_format_i_mem,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2648,11 +2751,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_i(word);
 			cpu.x[f.rd] = match cpu.mmu.load(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i_mem
+		disassemble: dump_format_i_mem,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2660,13 +2763,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "LD",
 		operation: |cpu, word, _address| {
 			let f = parse_format_i(word);
-			cpu.x[f.rd] = match cpu.mmu.load_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
+			cpu.x[f.rd] = match cpu
+				.mmu
+				.load_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64)
+			{
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i_mem
+		disassemble: dump_format_i_mem,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2674,13 +2780,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "LH",
 		operation: |cpu, word, _address| {
 			let f = parse_format_i(word);
-			cpu.x[f.rd] = match cpu.mmu.load_halfword(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
+			cpu.x[f.rd] = match cpu
+				.mmu
+				.load_halfword(cpu.x[f.rs1].wrapping_add(f.imm) as u64)
+			{
 				Ok(data) => data as i16 as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i_mem
+		disassemble: dump_format_i_mem,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2688,13 +2797,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "LHU",
 		operation: |cpu, word, _address| {
 			let f = parse_format_i(word);
-			cpu.x[f.rd] = match cpu.mmu.load_halfword(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
+			cpu.x[f.rd] = match cpu
+				.mmu
+				.load_halfword(cpu.x[f.rs1].wrapping_add(f.imm) as u64)
+			{
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i_mem
+		disassemble: dump_format_i_mem,
 	},
 	Instruction {
 		mask: 0xf9f0707f,
@@ -2708,12 +2820,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 					cpu.is_reservation_set = true;
 					cpu.reservation = cpu.x[f.rs1] as u64; // Is virtual address ok?
 					data as i64
-				},
-				Err(e) => return Err(e)
+				}
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf9f0707f,
@@ -2727,12 +2839,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 					cpu.is_reservation_set = true;
 					cpu.reservation = cpu.x[f.rs1] as u64; // Is virtual address ok?
 					data as i32 as i64
-				},
-				Err(e) => return Err(e)
+				}
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000007f,
@@ -2743,7 +2855,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = f.imm as i64;
 			Ok(())
 		},
-		disassemble: dump_format_u
+		disassemble: dump_format_u,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2753,11 +2865,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_i(word);
 			cpu.x[f.rd] = match cpu.mmu.load_word(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
 				Ok(data) => data as i32 as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i_mem
+		disassemble: dump_format_i_mem,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2767,11 +2879,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_i(word);
 			cpu.x[f.rd] = match cpu.mmu.load_word(cpu.x[f.rs1].wrapping_add(f.imm) as u64) {
 				Ok(data) => data as i64,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i_mem
+		disassemble: dump_format_i_mem,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2782,7 +2894,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_mul(cpu.x[f.rs2]));
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2791,16 +2903,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
 			cpu.x[f.rd] = match cpu.xlen {
-				Xlen::Bit32 => {
-					cpu.sign_extend((cpu.x[f.rs1] * cpu.x[f.rs2]) >> 32)
-				},
-				Xlen::Bit64 => {
-					((cpu.x[f.rs1] as i128) * (cpu.x[f.rs2] as i128) >> 64) as i64
-				}
+				Xlen::Bit32 => cpu.sign_extend((cpu.x[f.rs1] * cpu.x[f.rs2]) >> 32),
+				Xlen::Bit64 => ((cpu.x[f.rs1] as i128) * (cpu.x[f.rs2] as i128) >> 64) as i64,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2809,16 +2917,17 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
 			cpu.x[f.rd] = match cpu.xlen {
-				Xlen::Bit32 => {
-					cpu.sign_extend((((cpu.x[f.rs1] as u32 as u64) * (cpu.x[f.rs2] as u32 as u64)) >> 32) as i64)
-				},
+				Xlen::Bit32 => cpu.sign_extend(
+					(((cpu.x[f.rs1] as u32 as u64) * (cpu.x[f.rs2] as u32 as u64)) >> 32) as i64,
+				),
 				Xlen::Bit64 => {
-					((cpu.x[f.rs1] as u64 as u128).wrapping_mul(cpu.x[f.rs2] as u64 as u128) >> 64) as i64
+					((cpu.x[f.rs1] as u64 as u128).wrapping_mul(cpu.x[f.rs2] as u64 as u128) >> 64)
+						as i64
 				}
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2827,16 +2936,16 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
 			cpu.x[f.rd] = match cpu.xlen {
-				Xlen::Bit32 => {
-					cpu.sign_extend(((cpu.x[f.rs1] as i64).wrapping_mul(cpu.x[f.rs2] as u32 as i64) >> 32) as i64)
-				},
+				Xlen::Bit32 => cpu.sign_extend(
+					((cpu.x[f.rs1] as i64).wrapping_mul(cpu.x[f.rs2] as u32 as i64) >> 32) as i64,
+				),
 				Xlen::Bit64 => {
 					((cpu.x[f.rs1] as u128).wrapping_mul(cpu.x[f.rs2] as u64 as u128) >> 64) as i64
 				}
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2844,10 +2953,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "MULW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			cpu.x[f.rd] = cpu.sign_extend((cpu.x[f.rs1] as i32).wrapping_mul(cpu.x[f.rs2] as i32) as i64);
+			cpu.x[f.rd] =
+				cpu.sign_extend((cpu.x[f.rs1] as i32).wrapping_mul(cpu.x[f.rs2] as i32) as i64);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xffffffff,
@@ -2856,14 +2966,14 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		operation: |cpu, _word, _address| {
 			cpu.pc = match cpu.read_csr(CSR_MEPC_ADDRESS) {
 				Ok(data) => data,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			let status = cpu.read_csr_raw(CSR_MSTATUS_ADDRESS);
 			let mpie = (status >> 7) & 1;
 			let mpp = (status >> 11) & 0x3;
 			let mprv = match get_privilege_mode(mpp) {
 				PrivilegeMode::Machine => (status >> 17) & 1,
-				_ => 0
+				_ => 0,
 			};
 			// Override MIE[3] with MPIE[7], set MPIE[7] to 1, set MPP[12:11] to 0
 			// and override MPRV[17]
@@ -2873,12 +2983,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 				0 => PrivilegeMode::User,
 				1 => PrivilegeMode::Supervisor,
 				3 => PrivilegeMode::Machine,
-				_ => panic!() // Shouldn't happen
+				_ => panic!(), // Shouldn't happen
 			};
 			cpu.mmu.update_privilege_mode(cpu.privilege_mode.clone());
 			Ok(())
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2889,7 +2999,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] | cpu.x[f.rs2]);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2900,7 +3010,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] | f.imm);
 			Ok(())
 		},
-		disassemble: dump_format_i
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2919,7 +3029,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2931,11 +3041,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let divisor = cpu.unsigned_data(cpu.x[f.rs2]);
 			cpu.x[f.rd] = match divisor {
 				0 => cpu.sign_extend(dividend as i64),
-				_ => cpu.sign_extend(dividend.wrapping_rem(divisor) as i64)
+				_ => cpu.sign_extend(dividend.wrapping_rem(divisor) as i64),
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2947,11 +3057,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let divisor = cpu.x[f.rs2] as u32;
 			cpu.x[f.rd] = match divisor {
 				0 => dividend as i32 as i64,
-				_ => dividend.wrapping_rem(divisor) as i32 as i64
+				_ => dividend.wrapping_rem(divisor) as i32 as i64,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -2970,7 +3080,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			}
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -2978,9 +3088,10 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SB",
 		operation: |cpu, word, _address| {
 			let f = parse_format_s(word);
-			cpu.mmu.store(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u8)
+			cpu.mmu
+				.store(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u8)
 		},
-		disassemble: dump_format_s
+		disassemble: dump_format_s,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -2990,18 +3101,21 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			// @TODO: Implement properly
 			cpu.x[f.rd] = match cpu.is_reservation_set && cpu.reservation == (cpu.x[f.rs1] as u64) {
-				true => match cpu.mmu.store_doubleword(cpu.x[f.rs1] as u64, cpu.x[f.rs2] as u64) {
+				true => match cpu
+					.mmu
+					.store_doubleword(cpu.x[f.rs1] as u64, cpu.x[f.rs2] as u64)
+				{
 					Ok(()) => {
 						cpu.is_reservation_set = false;
 						0
-					},
-					Err(e) => return Err(e)
+					}
+					Err(e) => return Err(e),
 				},
-				false => 1
+				false => 1,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xf800707f,
@@ -3015,14 +3129,14 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 					Ok(()) => {
 						cpu.is_reservation_set = false;
 						0
-					},
-					Err(e) => return Err(e)
+					}
+					Err(e) => return Err(e),
 				},
-				false => 1
+				false => 1,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -3030,9 +3144,10 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SD",
 		operation: |cpu, word, _address| {
 			let f = parse_format_s(word);
-			cpu.mmu.store_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u64)
+			cpu.mmu
+				.store_doubleword(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u64)
 		},
-		disassemble: dump_format_s
+		disassemble: dump_format_s,
 	},
 	Instruction {
 		mask: 0xfe007fff,
@@ -3042,7 +3157,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			// Do nothing?
 			Ok(())
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -3050,9 +3165,10 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SH",
 		operation: |cpu, word, _address| {
 			let f = parse_format_s(word);
-			cpu.mmu.store_halfword(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u16)
+			cpu.mmu
+				.store_halfword(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u16)
 		},
-		disassemble: dump_format_s
+		disassemble: dump_format_s,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3063,7 +3179,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_shl(cpu.x[f.rs2] as u32));
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfc00707f,
@@ -3073,13 +3189,13 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let mask = match cpu.xlen {
 				Xlen::Bit32 => 0x1f,
-				Xlen::Bit64 => 0x3f
+				Xlen::Bit64 => 0x3f,
 			};
 			let shamt = (word >> 20) & mask;
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] << shamt);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3091,7 +3207,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = (cpu.x[f.rs1] << shamt) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3102,7 +3218,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = (cpu.x[f.rs1] as u32).wrapping_shl(cpu.x[f.rs2] as u32) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3112,11 +3228,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			cpu.x[f.rd] = match cpu.x[f.rs1] < cpu.x[f.rs2] {
 				true => 1,
-				false => 0
+				false => 0,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -3126,11 +3242,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_i(word);
 			cpu.x[f.rd] = match cpu.x[f.rs1] < f.imm {
 				true => 1,
-				false => 0
+				false => 0,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -3140,11 +3256,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_i(word);
 			cpu.x[f.rd] = match cpu.unsigned_data(cpu.x[f.rs1]) < cpu.unsigned_data(f.imm) {
 				true => 1,
-				false => 0
+				false => 0,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_i
+		disassemble: dump_format_i,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3154,11 +3270,11 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			cpu.x[f.rd] = match cpu.unsigned_data(cpu.x[f.rs1]) < cpu.unsigned_data(cpu.x[f.rs2]) {
 				true => 1,
-				false => 0
+				false => 0,
 			};
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3169,7 +3285,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_shr(cpu.x[f.rs2] as u32));
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfc00707f,
@@ -3179,13 +3295,13 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let mask = match cpu.xlen {
 				Xlen::Bit32 => 0x1f,
-				Xlen::Bit64 => 0x3f
+				Xlen::Bit64 => 0x3f,
 			};
 			let shamt = (word >> 20) & mask;
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] >> shamt);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfc00707f,
@@ -3197,7 +3313,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = ((cpu.x[f.rs1] as i32) >> shamt) as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3208,7 +3324,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = (cpu.x[f.rs1] as i32).wrapping_shr(cpu.x[f.rs2] as u32) as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xffffffff,
@@ -3218,14 +3334,14 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			// @TODO: Throw error if higher privilege return instruction is executed
 			cpu.pc = match cpu.read_csr(CSR_SEPC_ADDRESS) {
 				Ok(data) => data,
-				Err(e) => return Err(e)
+				Err(e) => return Err(e),
 			};
 			let status = cpu.read_csr_raw(CSR_SSTATUS_ADDRESS);
 			let spie = (status >> 5) & 1;
 			let spp = (status >> 8) & 1;
 			let mprv = match get_privilege_mode(spp) {
 				PrivilegeMode::Machine => (status >> 17) & 1,
-				_ => 0
+				_ => 0,
 			};
 			// Override SIE[1] with SPIE[5], set SPIE[5] to 1, set SPP[8] to 0,
 			// and override MPRV[17]
@@ -3234,12 +3350,12 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.privilege_mode = match spp {
 				0 => PrivilegeMode::User,
 				1 => PrivilegeMode::Supervisor,
-				_ => panic!() // Shouldn't happen
+				_ => panic!(), // Shouldn't happen
 			};
 			cpu.mmu.update_privilege_mode(cpu.privilege_mode.clone());
 			Ok(())
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3247,10 +3363,13 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SRL",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			cpu.x[f.rd] = cpu.sign_extend(cpu.unsigned_data(cpu.x[f.rs1]).wrapping_shr(cpu.x[f.rs2] as u32) as i64);
+			cpu.x[f.rd] = cpu.sign_extend(
+				cpu.unsigned_data(cpu.x[f.rs1])
+					.wrapping_shr(cpu.x[f.rs2] as u32) as i64,
+			);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfc00707f,
@@ -3260,13 +3379,13 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let mask = match cpu.xlen {
 				Xlen::Bit32 => 0x1f,
-				Xlen::Bit64 => 0x3f
+				Xlen::Bit64 => 0x3f,
 			};
 			let shamt = (word >> 20) & mask;
 			cpu.x[f.rd] = cpu.sign_extend((cpu.unsigned_data(cpu.x[f.rs1]) >> shamt) as i64);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfc00707f,
@@ -3276,13 +3395,13 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			let f = parse_format_r(word);
 			let mask = match cpu.xlen {
 				Xlen::Bit32 => 0x1f,
-				Xlen::Bit64 => 0x3f
+				Xlen::Bit64 => 0x3f,
 			};
 			let shamt = (word >> 20) & mask;
 			cpu.x[f.rd] = ((cpu.x[f.rs1] as u32) >> shamt) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3293,7 +3412,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = (cpu.x[f.rs1] as u32).wrapping_shr(cpu.x[f.rs2] as u32) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3304,7 +3423,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1].wrapping_sub(cpu.x[f.rs2]));
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3315,7 +3434,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.x[f.rs1].wrapping_sub(cpu.x[f.rs2]) as i32 as i64;
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -3323,9 +3442,10 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_s(word);
-			cpu.mmu.store_word(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u32)
+			cpu.mmu
+				.store_word(cpu.x[f.rs1].wrapping_add(f.imm) as u64, cpu.x[f.rs2] as u32)
 		},
-		disassemble: dump_format_s
+		disassemble: dump_format_s,
 	},
 	Instruction {
 		mask: 0xffffffff,
@@ -3335,7 +3455,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			// @TODO: Implement
 			panic!("URET instruction is not implemented yet.");
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0xffffffff,
@@ -3345,7 +3465,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.wfi = true;
 			Ok(())
 		},
-		disassemble: dump_empty
+		disassemble: dump_empty,
 	},
 	Instruction {
 		mask: 0xfe00707f,
@@ -3356,7 +3476,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] ^ cpu.x[f.rs2]);
 			Ok(())
 		},
-		disassemble: dump_format_r
+		disassemble: dump_format_r,
 	},
 	Instruction {
 		mask: 0x0000707f,
@@ -3367,7 +3487,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			cpu.x[f.rd] = cpu.sign_extend(cpu.x[f.rs1] ^ f.imm);
 			Ok(())
 		},
-		disassemble: dump_format_i
+		disassemble: dump_format_i,
 	},
 ];
 
@@ -3400,7 +3520,7 @@ struct DecodeCache {
 	/// Holds mappings from word instruction data to an index of `entries`
 	/// pointing to the entry having the decoding result. Containing the word
 	/// means cache hit.
-	hash_map: FnvHashMap::<u32, usize>,
+	hash_map: FnvHashMap<u32, usize>,
 
 	/// Holds the entries [`DecodeCacheEntry`](struct.DecodeCacheEntry.html)
 	/// forming linked list.
@@ -3416,7 +3536,7 @@ struct DecodeCache {
 	hit_count: u64,
 
 	/// Cache miss count for debugging purpose
-	miss_count: u64
+	miss_count: u64,
 }
 
 impl DecodeCache {
@@ -3427,11 +3547,11 @@ impl DecodeCache {
 		for i in 0..DECODE_CACHE_ENTRY_NUM {
 			let next_index = match i == DECODE_CACHE_ENTRY_NUM - 1 {
 				true => NULL_ENTRY,
-				false => i + 1
+				false => i + 1,
 			};
 			let prev_index = match i == 0 {
 				true => NULL_ENTRY,
-				false => i - 1
+				false => i - 1,
 			};
 			entries.push(DecodeCacheEntry::new(next_index, prev_index));
 		}
@@ -3442,7 +3562,7 @@ impl DecodeCache {
 			front_index: 0,
 			back_index: DECODE_CACHE_ENTRY_NUM - 1,
 			hit_count: 0,
-			miss_count: 0
+			miss_count: 0,
 		}
 	}
 
@@ -3477,7 +3597,7 @@ impl DecodeCache {
 					self.front_index = *index;
 				}
 				Some(self.entries[*index].instruction_index)
-			},
+			}
 			None => {
 				self.miss_count += 1;
 				None
@@ -3534,7 +3654,7 @@ struct DecodeCacheEntry {
 
 	/// Previous entry index in the linked list. [`NULL_ENTRY`](constant.NULL_ENTRY.html)
 	/// represents no previous entry, meaning the entry is at head.
-	prev_index: usize
+	prev_index: usize,
 }
 
 impl DecodeCacheEntry {
@@ -3549,16 +3669,16 @@ impl DecodeCacheEntry {
 			word: 0,
 			instruction_index: INVALID_CACHE_ENTRY,
 			next_index: next_index,
-			prev_index: prev_index
+			prev_index: prev_index,
 		}
 	}
 }
 
 #[cfg(test)]
 mod test_cpu {
-	use terminal::DummyTerminal;
-	use mmu::DRAM_BASE;
 	use super::*;
+	use mmu::DRAM_BASE;
+	use terminal::DummyTerminal;
 
 	fn create_cpu() -> Cpu {
 		Cpu::new(Box::new(DummyTerminal::new()))
@@ -3611,7 +3731,7 @@ mod test_cpu {
 			match i {
 				// 0th register is hardwired zero
 				0 => assert_eq!(0, cpu.read_register(i)),
-				_ => assert_eq!(i as i64 + 1, cpu.read_register(i))
+				_ => assert_eq!(i as i64 + 1, cpu.read_register(i)),
 			}
 		}
 
@@ -3623,7 +3743,7 @@ mod test_cpu {
 			match i {
 				// 0th register is hardwired zero
 				0 => assert_eq!(0, cpu.read_register(i)),
-				_ => assert_eq!(-(i as i64 + 1), cpu.read_register(i))
+				_ => assert_eq!(-(i as i64 + 1), cpu.read_register(i)),
 			}
 		}
 
@@ -3639,13 +3759,13 @@ mod test_cpu {
 
 		// Write non-compressed "addi x1, x1, 1" instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, 0x00108093) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 		// Write compressed "addi x8, x0, 8" instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE + 4, 0x20) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 
 		cpu.tick();
@@ -3666,14 +3786,14 @@ mod test_cpu {
 		cpu.update_pc(DRAM_BASE);
 		// write non-compressed "addi a0, a0, 12" instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, 0xc50513) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 		assert_eq!(DRAM_BASE, cpu.read_pc());
 		assert_eq!(0, cpu.read_register(10));
 		match cpu.tick_operate() {
-			Ok(()) => {},
-			Err(_e) => panic!("tick_operate() unexpectedly did panic")
+			Ok(()) => {}
+			Err(_e) => panic!("tick_operate() unexpectedly did panic"),
 		};
 		// .tick_operate() increments the program counter by 4 for
 		// non-compressed instruction.
@@ -3693,20 +3813,20 @@ mod test_cpu {
 		cpu.get_mut_mmu().init_memory(4);
 		cpu.update_pc(DRAM_BASE);
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, 0xaaaaaaaa) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 		match cpu.fetch() {
 			Ok(data) => assert_eq!(0xaaaaaaaa, data),
-			Err(_e) => panic!("Failed to fetch")
+			Err(_e) => panic!("Failed to fetch"),
 		};
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, 0x55555555) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 		match cpu.fetch() {
 			Ok(data) => assert_eq!(0x55555555, data),
-			Err(_e) => panic!("Failed to fetch")
+			Err(_e) => panic!("Failed to fetch"),
 		};
 		// @TODO: Write test cases where Trap happens
 	}
@@ -3717,12 +3837,12 @@ mod test_cpu {
 		// 0x13 is addi instruction
 		match cpu.decode(0x13) {
 			Ok(inst) => assert_eq!(inst.name, "ADDI"),
-			Err(_e) => panic!("Failed to decode")
+			Err(_e) => panic!("Failed to decode"),
 		};
 		// .decode() returns error for invalid word data.
 		match cpu.decode(0x0) {
 			Ok(_inst) => panic!("Unexpectedly succeeded in decoding"),
-			Err(()) => assert!(true)
+			Err(()) => assert!(true),
 		};
 		// @TODO: Should I test all instructions?
 	}
@@ -3734,7 +3854,7 @@ mod test_cpu {
 		// it returns uncompressed word. Then you need to call .decode().
 		match cpu.decode(cpu.uncompress(0x20)) {
 			Ok(inst) => assert_eq!(inst.name, "ADDI"),
-			Err(_e) => panic!("Failed to decode")
+			Err(_e) => panic!("Failed to decode"),
 		};
 		// @TODO: Should I test all compressed instructions?
 	}
@@ -3746,14 +3866,14 @@ mod test_cpu {
 		// Just in case
 		match cpu.decode(wfi_instruction) {
 			Ok(inst) => assert_eq!(inst.name, "WFI"),
-			Err(_e) => panic!("Failed to decode")
+			Err(_e) => panic!("Failed to decode"),
 		};
 		cpu.get_mut_mmu().init_memory(4);
 		cpu.update_pc(DRAM_BASE);
 		// write WFI instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, wfi_instruction) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 		cpu.tick();
 		assert_eq!(DRAM_BASE + 4, cpu.read_pc());
@@ -3780,8 +3900,8 @@ mod test_cpu {
 		cpu.get_mut_mmu().init_memory(4);
 		// Write non-compressed "addi x0, x0, 1" instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, 0x00100013) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 		cpu.update_pc(DRAM_BASE);
 
@@ -3821,8 +3941,8 @@ mod test_cpu {
 		cpu.get_mut_mmu().init_memory(4);
 		// Write ECALL instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, 0x00000073) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 		cpu.write_csr_raw(CSR_MTVEC_ADDRESS, handler_vector);
 		cpu.update_pc(DRAM_BASE);
@@ -3849,25 +3969,25 @@ mod test_cpu {
 
 		// Write non-compressed "addi x0, x0, 1" instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, 0x00100013) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 		// Write non-compressed "addi x1, x1, 1" instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE + 4, 0x00108093) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 
 		// Test x0
 		assert_eq!(0, cpu.read_register(0));
 		cpu.tick(); // Execute  "addi x0, x0, 1"
-		// x0 is still zero because it's hardcoded zero
+			  // x0 is still zero because it's hardcoded zero
 		assert_eq!(0, cpu.read_register(0));
 
 		// Test x1
 		assert_eq!(0, cpu.read_register(1));
 		cpu.tick(); // Execute  "addi x1, x1, 1"
-		// x1 is not hardcoded zero
+			  // x1 is not hardcoded zero
 		assert_eq!(1, cpu.read_register(1));
 	}
 
@@ -3879,12 +3999,14 @@ mod test_cpu {
 
 		// Write non-compressed "addi x0, x0, 1" instruction
 		match cpu.get_mut_mmu().store_word(DRAM_BASE, 0x00100013) {
-			Ok(()) => {},
-			Err(_e) => panic!("Failed to store")
+			Ok(()) => {}
+			Err(_e) => panic!("Failed to store"),
 		};
 
-		assert_eq!("PC:0000000080000000 00100013 ADDI zero:0,zero:0,1",
-			cpu.disassemble_next_instruction());
+		assert_eq!(
+			"PC:0000000080000000 00100013 ADDI zero:0,zero:0,1",
+			cpu.disassemble_next_instruction()
+		);
 
 		// No effect to PC
 		assert_eq!(DRAM_BASE, cpu.read_pc());
@@ -3915,7 +4037,7 @@ mod test_decode_cache {
 		// Cache hit test
 		match cache.get(1) {
 			Some(index) => assert_eq!(2, index),
-			None => panic!("Unexpected cache miss")
+			None => panic!("Unexpected cache miss"),
 		};
 
 		// Cache miss test
@@ -3932,7 +4054,7 @@ mod test_decode_cache {
 
 		match cache.get(0) {
 			Some(index) => assert_eq!(1, index),
-			None => panic!("Unexpected cache miss")
+			None => panic!("Unexpected cache miss"),
 		};
 
 		for i in 1..DECODE_CACHE_ENTRY_NUM + 1 {
@@ -3953,7 +4075,10 @@ mod test_decode_cache {
 		};
 
 		// The oldest entry with the word "2" will be removed due to the overflow
-		cache.insert(DECODE_CACHE_ENTRY_NUM as u32 + 1, DECODE_CACHE_ENTRY_NUM + 2);
+		cache.insert(
+			DECODE_CACHE_ENTRY_NUM as u32 + 1,
+			DECODE_CACHE_ENTRY_NUM + 2,
+		);
 
 		match cache.get(2) {
 			Some(_index) => panic!("Unexpected cache hit"),

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -997,22 +997,6 @@ impl Cpu {
 							}
 						}
 					}
-					5 => {
-						// C.J
-						// jal x0, offset
-						let imm = match halfword & 0x1000 {
-							0x1000 => 0xfff00000,
-							_ => 0
-						} | // imm[31:20] <= [12]
-						((halfword & 0x800) << 9) | // imm[11] <= [11]
-						((halfword & 0x400) << 8) | // imm[10] <= [10]
-						((halfword & 0x300) << 7) | // imm[9:8] <= [9:8]
-						((halfword & 0x80) << 4) | // imm[7] <= [7]
-						((halfword & 0x40) << 4) | // imm[6] <= [6]
-						((halfword & 0x20) << 4) | // imm[5] <= [5]
-						((halfword & 0x10) << 4); // imm[4] <= [4]
-						return (imm << 12) | 0x6f;
-					}
 					1 => {
 						// @TODO: Support C.JAL in 32-bit mode
 						// C.ADDIW

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1301,39 +1301,48 @@ impl Cpu {
 						let rs2 = (halfword >> 2) & 0x1f; // [6:2]
 						match funct1 {
 							0 => {
-								if rs1 != 0 && rs2 == 0 {
-									// C.JR
-									// jalr x0, 0(rs1)
-									return (rs1 << 15) | 0x67;
+								// C.MV
+								match (rs1, rs2) {
+									(0, 0) => {
+										// Reserved
+									}
+									(r, 0) if r != 0 => {
+										// C.JR: jalr x0, 0(rs1)
+										return (rs1 << 15) | 0x67;
+									}
+									(0, r2) if r2 != 0 => {
+										// HINT
+										return 0x13;
+									}
+									(rd, rs2) => {
+										// add rd, x0, rs2
+										return (rs2 << 20) | (rd << 7) | 0x33;
+									}
 								}
-								// rs1 == 0 is reserved instruction
-								if rs1 != 0 && rs2 != 0 {
-									// C.MV
-									// add rs1, x0, rs2
-									// println!("C.MV RS1:{:x} RS2:{:x}", rs1, rs2);
-									return (rs2 << 20) | (rs1 << 7) | 0x33;
-								}
-								// rs1 == 0 && rs2 != 0 is Hints
-								// @TODO: Support Hints
 							}
 							1 => {
-								if rs1 == 0 && rs2 == 0 {
-									// C.EBREAK
-									// ebreak
-									return 0x00100073;
+								// C.ADD
+								match (rs1, rs2) {
+									(0, 0) => {
+										// C.EBREAK
+										// ebreak
+										return 0x00100073;
+									}
+									(r1, 0) if r1 != 0 => {
+										// C.JALR
+										// jalr x1, 0(rs1)
+										return (rs1 << 15) | (1 << 7) | 0x67;
+									}
+									(0, r2) if r2 != 0 => {
+										// HINT
+										return 0x13;
+									}
+									(rd, rs2) => {
+										// C.ADD
+										// add rs1, rs1, rs2
+										return (rs2 << 20) | (rs1 << 15) | (rs1 << 7) | 0x33;
+									}
 								}
-								if rs1 != 0 && rs2 == 0 {
-									// C.JALR
-									// jalr x1, 0(rs1)
-									return (rs1 << 15) | (1 << 7) | 0x67;
-								}
-								if rs1 != 0 && rs2 != 0 {
-									// C.ADD
-									// add rs1, rs1, rs2
-									return (rs2 << 20) | (rs1 << 15) | (rs1 << 7) | 0x33;
-								}
-								// rs1 == 0 && rs2 != 0 is Hists
-								// @TODO: Supports Hinsts
 							}
 							_ => {} // Not happens
 						};

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1806,7 +1806,7 @@ fn get_register_name(num: usize) -> &'static str {
 	}
 }
 
-const INSTRUCTION_NUM: usize = 116;
+const INSTRUCTION_NUM: usize = 117;
 
 // @TODO: Reorder in often used order as
 const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
@@ -3540,6 +3540,27 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 			Ok(())
 		},
 		disassemble: dump_format_i,
+	},
+	Instruction {
+		mask: 0xf800707f,
+		data: 0x2000202f,
+		name: "AMOXOR.W",
+		operation: |cpu, word, _address| {
+			let f = parse_format_r(word);
+			let addr = cpu.x[f.rs1] as u64;
+			let orig = match cpu.mmu.load_word(addr) {
+				Ok(data) => data as i32 as i64,
+				Err(e) => return Err(e),
+			};
+			let result = (orig as u32) ^ (cpu.x[f.rs2] as u32);
+			match cpu.mmu.store_word(addr, result) {
+				Ok(()) => {},
+				Err(e) => return Err(e),
+			};
+			cpu.x[f.rd] = orig;
+			Ok(())
+		},
+		disassemble: dump_format_r,
 	},
 ];
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3208,8 +3208,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SLLIW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			let shamt = f.rs2 as u32;
-			cpu.x[f.rd] = (cpu.x[f.rs1] << shamt) as i32 as i64;
+			cpu.x[f.rd] = (cpu.x[f.rs1] << f.rs2) as i32 as i64;
 			Ok(())
 		},
 		disassemble: dump_format_r,
@@ -3314,8 +3313,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SRAIW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			let shamt = ((word >> 20) & 0x1f) as u32;
-			cpu.x[f.rd] = ((cpu.x[f.rs1] as i32) >> shamt) as i64;
+			cpu.x[f.rd] = ((cpu.x[f.rs1] as i32) >> f.rs2) as i64;
 			Ok(())
 		},
 		disassemble: dump_format_r,
@@ -3402,12 +3400,7 @@ const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
 		name: "SRLIW",
 		operation: |cpu, word, _address| {
 			let f = parse_format_r(word);
-			let mask = match cpu.xlen {
-				Xlen::Bit32 => 0x1f,
-				Xlen::Bit64 => 0x3f,
-			};
-			let shamt = (word >> 20) & mask;
-			cpu.x[f.rd] = ((cpu.x[f.rs1] as u32) >> shamt) as i32 as i64;
+			cpu.x[f.rd] = ((cpu.x[f.rs1] as u32) >> f.rs2) as i32 as i64;
 			Ok(())
 		},
 		disassemble: dump_format_r,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -989,6 +989,22 @@ impl Cpu {
 						// @TODO: Support HINTs
 						// r == 0 and imm != 0 is HINTs
 					}
+					5 => {
+						// C.J
+						// jal x0, offset
+						let imm = match halfword & 0x1000 {
+							0x1000 => 0xfff00000,
+							_ => 0
+						} | // imm[31:20] <= [12]
+						((halfword & 0x800) << 9) | // imm[11] <= [11]
+						((halfword & 0x400) << 8) | // imm[10] <= [10]
+						((halfword & 0x300) << 7) | // imm[9:8] <= [9:8]
+						((halfword & 0x80) << 4) | // imm[7] <= [7]
+						((halfword & 0x40) << 4) | // imm[6] <= [6]
+						((halfword & 0x20) << 4) | // imm[5] <= [5]
+						((halfword & 0x10) << 4); // imm[4] <= [4]
+						return (imm << 12) | 0x6f;
+					}
 					1 => {
 						// @TODO: Support C.JAL in 32-bit mode
 						// C.ADDIW

--- a/src/default_terminal.rs
+++ b/src/default_terminal.rs
@@ -3,14 +3,14 @@ use terminal::Terminal;
 /// Standard `Terminal`.
 pub struct DefaultTerminal {
 	input_data: Vec<u8>,
-	output_data: Vec<u8>
+	output_data: Vec<u8>,
 }
 
 impl DefaultTerminal {
 	pub fn new() -> Self {
 		DefaultTerminal {
 			input_data: vec![],
-			output_data: vec![]
+			output_data: vec![],
 		}
 	}
 }
@@ -19,22 +19,22 @@ impl Terminal for DefaultTerminal {
 	fn put_byte(&mut self, value: u8) {
 		self.output_data.push(value);
 	}
-	
+
 	fn get_input(&mut self) -> u8 {
 		match self.input_data.len() > 0 {
 			true => self.input_data.remove(0),
-			false => 0
+			false => 0,
 		}
 	}
-	
+
 	fn put_input(&mut self, value: u8) {
 		self.input_data.push(value);
 	}
-	
+
 	fn get_output(&mut self) -> u8 {
 		match self.output_data.len() > 0 {
 			true => self.output_data.remove(0),
-			false => 0
+			false => 0,
 		}
 	}
 }

--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -6,7 +6,7 @@ pub struct Clint {
 	clock: u64,
 	msip: u32,
 	mtimecmp: u64,
-	mtime: u64
+	mtime: u64,
 }
 
 impl Clint {
@@ -16,7 +16,7 @@ impl Clint {
 			clock: 0,
 			msip: 0,
 			mtimecmp: 0,
-			mtime: 0 // @TODO: Should be bound to csr time register
+			mtime: 0, // @TODO: Should be bound to csr time register
 		}
 	}
 
@@ -46,67 +46,27 @@ impl Clint {
 		//println!("CLINT Load AD:{:X}", address);
 		match address {
 			// MSIP register 4 bytes
-			0x02000000 => {
-				(self.msip & 0xff) as u8
-			},
-			0x02000001 => {
-				((self.msip >> 8) & 0xff) as u8
-			},
-			0x02000002 => {
-				((self.msip >> 16) & 0xff) as u8
-			},
-			0x02000003 => {
-				((self.msip >> 24) & 0xff) as u8
-			},
+			0x02000000 => (self.msip & 0xff) as u8,
+			0x02000001 => ((self.msip >> 8) & 0xff) as u8,
+			0x02000002 => ((self.msip >> 16) & 0xff) as u8,
+			0x02000003 => ((self.msip >> 24) & 0xff) as u8,
 			// MTIMECMP Registers 8 bytes
-			0x02004000 => {
-				self.mtimecmp as u8
-			},
-			0x02004001 => {
-				(self.mtimecmp >> 8) as u8
-			},
-			0x02004002 => {
-				(self.mtimecmp >> 16) as u8
-			},
-			0x02004003 => {
-				(self.mtimecmp >> 24) as u8
-			},
-			0x02004004 => {
-				(self.mtimecmp >> 32) as u8
-			},
-			0x02004005 => {
-				(self.mtimecmp >> 40) as u8
-			},
-			0x02004006 => {
-				(self.mtimecmp >> 48) as u8
-			},
-			0x02004007 => {
-				(self.mtimecmp >> 56) as u8
-			},
-			0x0200bff8 => {
-				self.mtime as u8
-			},
-			0x0200bff9 => {
-				(self.mtime >> 8) as u8
-			},
-			0x0200bffa => {
-				(self.mtime >> 16) as u8
-			},
-			0x0200bffb => {
-				(self.mtime >> 24) as u8
-			},
-			0x0200bffc => {
-				(self.mtime >> 32) as u8
-			},
-			0x0200bffd => {
-				(self.mtime >> 40) as u8
-			},
-			0x0200bffe => {
-				(self.mtime >> 48) as u8
-			},
-			0x0200bfff => {
-				(self.mtime >> 56) as u8
-			},
+			0x02004000 => self.mtimecmp as u8,
+			0x02004001 => (self.mtimecmp >> 8) as u8,
+			0x02004002 => (self.mtimecmp >> 16) as u8,
+			0x02004003 => (self.mtimecmp >> 24) as u8,
+			0x02004004 => (self.mtimecmp >> 32) as u8,
+			0x02004005 => (self.mtimecmp >> 40) as u8,
+			0x02004006 => (self.mtimecmp >> 48) as u8,
+			0x02004007 => (self.mtimecmp >> 56) as u8,
+			0x0200bff8 => self.mtime as u8,
+			0x0200bff9 => (self.mtime >> 8) as u8,
+			0x0200bffa => (self.mtime >> 16) as u8,
+			0x0200bffb => (self.mtime >> 24) as u8,
+			0x0200bffc => (self.mtime >> 32) as u8,
+			0x0200bffd => (self.mtime >> 40) as u8,
+			0x0200bffe => (self.mtime >> 48) as u8,
+			0x0200bfff => (self.mtime >> 56) as u8,
 			_ => 0,
 		}
 	}
@@ -122,57 +82,57 @@ impl Clint {
 			// MSIP register 4 bytes. Upper 31 bits are hardwired to zero.
 			0x02000000 => {
 				self.msip = (self.msip & !0x1) | ((value & 1) as u32);
-			},
+			}
 			// MTIMECMP Registers 8 bytes
 			0x02004000 => {
 				self.mtimecmp = (self.mtimecmp & !0xff) | (value as u64);
-			},
+			}
 			0x02004001 => {
 				self.mtimecmp = (self.mtimecmp & !(0xff << 8)) | ((value as u64) << 8);
-			},
+			}
 			0x02004002 => {
 				self.mtimecmp = (self.mtimecmp & !(0xff << 16)) | ((value as u64) << 16);
-			},
+			}
 			0x02004003 => {
 				self.mtimecmp = (self.mtimecmp & !(0xff << 24)) | ((value as u64) << 24);
-			},
+			}
 			0x02004004 => {
 				self.mtimecmp = (self.mtimecmp & !(0xff << 32)) | ((value as u64) << 32);
-			},
+			}
 			0x02004005 => {
 				self.mtimecmp = (self.mtimecmp & !(0xff << 40)) | ((value as u64) << 40);
-			},
+			}
 			0x02004006 => {
 				self.mtimecmp = (self.mtimecmp & !(0xff << 48)) | ((value as u64) << 48);
-			},
+			}
 			0x02004007 => {
 				self.mtimecmp = (self.mtimecmp & !(0xff << 56)) | ((value as u64) << 56);
-			},
+			}
 			// MTIME registers 8 bytes
 			0x0200bff8 => {
 				self.mtime = (self.mtime & !0xff) | (value as u64);
-			},
+			}
 			0x0200bff9 => {
 				self.mtime = (self.mtime & !(0xff << 8)) | ((value as u64) << 8);
-			},
+			}
 			0x0200bffa => {
 				self.mtime = (self.mtime & !(0xff << 16)) | ((value as u64) << 16);
-			},
+			}
 			0x0200bffb => {
 				self.mtime = (self.mtime & !(0xff << 24)) | ((value as u64) << 24);
-			},
+			}
 			0x0200bffc => {
 				self.mtime = (self.mtime & !(0xff << 32)) | ((value as u64) << 32);
-			},
+			}
 			0x0200bffd => {
 				self.mtime = (self.mtime & !(0xff << 40)) | ((value as u64) << 40);
-			},
+			}
 			0x0200bffe => {
 				self.mtime = (self.mtime & !(0xff << 48)) | ((value as u64) << 48);
-			},
+			}
 			0x0200bfff => {
 				self.mtime = (self.mtime & !(0xff << 56)) | ((value as u64) << 56);
-			},
+			}
 			_ => {}
 		};
 	}

--- a/src/device/plic.rs
+++ b/src/device/plic.rs
@@ -14,7 +14,7 @@ pub struct Plic {
 	ips: [u8; 1024],
 	priorities: [u32; 1024],
 	needs_update_irq: bool,
-	virtio_ip_cache: bool
+	virtio_ip_cache: bool,
 }
 
 // @TODO: IRQ numbers should be configurable with device tree
@@ -32,7 +32,7 @@ impl Plic {
 			priorities: [0; 1024],
 			ips: [0; 1024],
 			needs_update_irq: false,
-			virtio_ip_cache: false
+			virtio_ip_cache: false,
 		}
 	}
 
@@ -95,11 +95,9 @@ impl Plic {
 		let mut irq = 0;
 		let mut priority = 0;
 		for i in 0..2 {
-			if ips[i] && enables[i] &&
-				priorities[i] > self.threshold &&
-				priorities[i] > priority {
-					irq = irqs[i];
-					priority = priorities[i];
+			if ips[i] && enables[i] && priorities[i] > self.threshold && priorities[i] > priority {
+				irq = irqs[i];
+				priority = priorities[i];
 			}
 		}
 
@@ -134,11 +132,11 @@ impl Plic {
 				let index = ((address - 0xc000000) >> 2) as usize;
 				let pos = offset << 3;
 				(self.priorities[index] >> pos) as u8
-			},
+			}
 			0x0c001000..=0x0c00107f => {
 				let index = (address - 0xc001000) as usize;
 				self.ips[index]
-			},
+			}
 			0x0c002080 => self.enabled as u8,
 			0x0c002081 => (self.enabled >> 8) as u8,
 			0x0c002082 => (self.enabled >> 16) as u8,
@@ -155,7 +153,7 @@ impl Plic {
 			0x0c201005 => (self.irq >> 8) as u8,
 			0x0c201006 => (self.irq >> 16) as u8,
 			0x0c201007 => (self.irq >> 24) as u8,
-			_ => 0
+			_ => 0,
 		}
 	}
 
@@ -171,55 +169,56 @@ impl Plic {
 				let offset = address % 4;
 				let index = ((address - 0xc000000) >> 2) as usize;
 				let pos = offset << 3;
-				self.priorities[index] = (self.priorities[index] & !(0xff << pos)) | ((value as u32) << pos);
+				self.priorities[index] =
+					(self.priorities[index] & !(0xff << pos)) | ((value as u32) << pos);
 				self.needs_update_irq = true;
-			},
+			}
 			// Enable. Only first 64 interrupt sources support so far.
 			// @TODO: Implement all 1024 interrupt source enables.
 			0x0c002080 => {
 				self.enabled = (self.enabled & !0xff) | (value as u64);
 				self.needs_update_irq = true;
-			},
+			}
 			0x0c002081 => {
 				self.enabled = (self.enabled & !(0xff << 8)) | ((value as u64) << 8);
-			},
+			}
 			0x0c002082 => {
 				self.enabled = (self.enabled & !(0xff << 16)) | ((value as u64) << 16);
-			},
+			}
 			0x0c002083 => {
 				self.enabled = (self.enabled & !(0xff << 24)) | ((value as u64) << 24);
-			},
+			}
 			0x0c002084 => {
 				self.enabled = (self.enabled & !(0xff << 32)) | ((value as u64) << 32);
-			},
+			}
 			0x0c002085 => {
 				self.enabled = (self.enabled & !(0xff << 40)) | ((value as u64) << 40);
-			},
+			}
 			0x0c002086 => {
 				self.enabled = (self.enabled & !(0xff << 48)) | ((value as u64) << 48);
-			},
+			}
 			0x0c002087 => {
 				self.enabled = (self.enabled & !(0xff << 56)) | ((value as u64) << 56);
-			},
+			}
 			0x0c201000 => {
 				self.threshold = (self.threshold & !0xff) | (value as u32);
 				self.needs_update_irq = true;
-			},
+			}
 			0x0c201001 => {
 				self.threshold = (self.threshold & !(0xff << 8)) | ((value as u32) << 8);
-			},
+			}
 			0x0c201002 => {
 				self.threshold = (self.threshold & !(0xff << 16)) | ((value as u32) << 16);
-			},
+			}
 			0x0c201003 => {
 				self.threshold = (self.threshold & !(0xff << 24)) | ((value as u32) << 24);
-			},
+			}
 			// Claim
 			0x0c201004 => {
 				// Assuming written data is a byte so far
 				// @TODO: Should be four bytes.
 				self.clear_ip(value as u32);
-			},
+			}
 			_ => {}
 		};
 	}

--- a/src/device/uart.rs
+++ b/src/device/uart.rs
@@ -24,7 +24,7 @@ pub struct Uart {
 	scr: u8, // scratch,
 	thre_ip: bool,
 	interrupting: bool,
-	terminal: Box<dyn Terminal>
+	terminal: Box<dyn Terminal>,
 }
 
 impl Uart {
@@ -42,7 +42,7 @@ impl Uart {
 			scr: 0,
 			thre_ip: false,
 			interrupting: false,
-			terminal: terminal
+			terminal: terminal,
 		}
 	}
 
@@ -127,19 +127,19 @@ impl Uart {
 					self.lsr &= !LSR_DATA_AVAILABLE;
 					self.update_iir();
 					rbr
-				},
-				false => 0 // @TODO: Implement properly
+				}
+				false => 0, // @TODO: Implement properly
 			},
 			0x10000001 => match (self.lcr >> 7) == 0 {
 				true => self.ier,
-				false => 0 // @TODO: Implement properly
+				false => 0, // @TODO: Implement properly
 			},
 			0x10000002 => self.iir,
 			0x10000003 => self.lcr,
 			0x10000004 => self.mcr,
 			0x10000005 => self.lsr,
 			0x10000007 => self.scr,
-			_ => 0
+			_ => 0,
 		}
 	}
 
@@ -157,32 +157,33 @@ impl Uart {
 					self.thr = value;
 					self.lsr &= !LSR_THR_EMPTY;
 					self.update_iir();
-				},
+				}
 				false => {} // @TODO: Implement properly
 			},
 			0x10000001 => match (self.lcr >> 7) == 0 {
 				true => {
 					// This bahavior isn't written in the data sheet
 					// but some drivers seem to rely on it.
-					if (self.ier & IER_THREINT_BIT) == 0 &&
-						(value & IER_THREINT_BIT) != 0 &&
-						self.thr == 0 {
+					if (self.ier & IER_THREINT_BIT) == 0
+						&& (value & IER_THREINT_BIT) != 0
+						&& self.thr == 0
+					{
 						self.thre_ip = true;
 					}
 					self.ier = value;
 					self.update_iir();
-				},
+				}
 				false => {} // @TODO: Implement properly
 			},
 			0x10000003 => {
 				self.lcr = value;
-			},
+			}
 			0x10000004 => {
 				self.mcr = value;
-			},
+			}
 			0x10000007 => {
 				self.scr = value;
-			},
+			}
 			_ => {}
 		};
 	}

--- a/src/device/virtio_block_disk.rs
+++ b/src/device/virtio_block_disk.rs
@@ -23,20 +23,20 @@ const SECTOR_SIZE: u64 = 512;
 pub struct VirtioBlockDisk {
 	used_ring_index: u16,
 	clock: u64,
-	device_features: u64, // read only
-	device_features_sel: u32, // write only
-	driver_features: u32, // write only
+	device_features: u64,      // read only
+	device_features_sel: u32,  // write only
+	driver_features: u32,      // write only
 	_driver_features_sel: u32, // write only
-	guest_page_size: u32, // write only
-	queue_select: u32, // write only
-	queue_size: u32, // write only
-	queue_align: u32, // write only
-	queue_pfn: u32, // read and write
-	queue_notify: u32, // write only
-	interrupt_status: u32, // read only
-	status: u32, // read and write
-	notify_clocks: Vec::<u64>,
-	contents: Vec<u64>
+	guest_page_size: u32,      // write only
+	queue_select: u32,         // write only
+	queue_size: u32,           // write only
+	queue_align: u32,          // write only
+	queue_pfn: u32,            // read and write
+	queue_notify: u32,         // write only
+	interrupt_status: u32,     // read only
+	status: u32,               // read and write
+	notify_clocks: Vec<u64>,
+	contents: Vec<u64>,
 }
 
 impl VirtioBlockDisk {
@@ -58,7 +58,7 @@ impl VirtioBlockDisk {
 			status: 0,
 			interrupt_status: 0,
 			notify_clocks: Vec::new(),
-			contents: vec![]
+			contents: vec![],
 		}
 	}
 
@@ -80,7 +80,8 @@ impl VirtioBlockDisk {
 		for i in 0..contents.len() {
 			let index = (i >> 3) as usize;
 			let pos = (i % 8) * 8;
-			self.contents[index] = (self.contents[index] & !(0xff << pos)) | ((contents[i] as u64) << pos);
+			self.contents[index] =
+				(self.contents[index] & !(0xff << pos)) | ((contents[i] as u64) << pos);
 		}
 	}
 
@@ -90,7 +91,8 @@ impl VirtioBlockDisk {
 	/// # Arguments
 	/// * `memory`
 	pub fn tick(&mut self, memory: &mut MemoryWrapper) {
-		if self.notify_clocks.len() > 0 && (self.clock == self.notify_clocks[0] + DISK_ACCESS_DELAY) {
+		if self.notify_clocks.len() > 0 && (self.clock == self.notify_clocks[0] + DISK_ACCESS_DELAY)
+		{
 			// bit 0 in interrupt_status register indicates
 			// the interrupt was asserted because the device has used a buffer
 			// in at least one of the active virtual queues.
@@ -124,9 +126,15 @@ impl VirtioBlockDisk {
 			0x1000100f => 0x55,
 			// Flags representing features the device supports
 			0x10001010 => ((self.device_features >> (self.device_features_sel * 32)) & 0xff) as u8,
-			0x10001011 => (((self.device_features >> (self.device_features_sel * 32)) >> 8) & 0xff) as u8,
-			0x10001012 => (((self.device_features >> (self.device_features_sel * 32)) >> 16) & 0xff) as u8,
-			0x10001013 => (((self.device_features >> (self.device_features_sel * 32)) >> 24) & 0xff) as u8,
+			0x10001011 => {
+				(((self.device_features >> (self.device_features_sel * 32)) >> 8) & 0xff) as u8
+			}
+			0x10001012 => {
+				(((self.device_features >> (self.device_features_sel * 32)) >> 16) & 0xff) as u8
+			}
+			0x10001013 => {
+				(((self.device_features >> (self.device_features_sel * 32)) >> 24) & 0xff) as u8
+			}
 			// Maximum virtual queue size
 			0x10001034 => MAX_QUEUE_SIZE as u8,
 			0x10001035 => (MAX_QUEUE_SIZE >> 8) as u8,
@@ -156,7 +164,7 @@ impl VirtioBlockDisk {
 			0x10001105 => 0,
 			0x10001106 => 0,
 			0x10001107 => 0,
-			_ => 0
+			_ => 0,
 		}
 	}
 
@@ -170,105 +178,114 @@ impl VirtioBlockDisk {
 		match address {
 			0x10001014 => {
 				self.device_features_sel = (self.device_features_sel & !0xff) | (value as u32);
-			},
+			}
 			0x10001015 => {
-				self.device_features_sel = (self.device_features_sel & !(0xff << 8)) | ((value as u32) << 8);
-			},
+				self.device_features_sel =
+					(self.device_features_sel & !(0xff << 8)) | ((value as u32) << 8);
+			}
 			0x10001016 => {
-				self.device_features_sel = (self.device_features_sel & !(0xff << 16)) | ((value as u32) << 16);			
-			},
+				self.device_features_sel =
+					(self.device_features_sel & !(0xff << 16)) | ((value as u32) << 16);
+			}
 			0x10001017 => {
-				self.device_features_sel = (self.device_features_sel & !(0xff << 24)) | ((value as u32) << 24);
-			},
+				self.device_features_sel =
+					(self.device_features_sel & !(0xff << 24)) | ((value as u32) << 24);
+			}
 			0x10001020 => {
 				self.driver_features = (self.driver_features & !0xff) | (value as u32);
-			},
+			}
 			0x10001021 => {
-				self.driver_features = (self.driver_features & !(0xff << 8)) | ((value as u32) << 8);
-			},
+				self.driver_features =
+					(self.driver_features & !(0xff << 8)) | ((value as u32) << 8);
+			}
 			0x10001022 => {
-				self.driver_features = (self.driver_features & !(0xff << 16)) | ((value as u32) << 16);			
-			},
+				self.driver_features =
+					(self.driver_features & !(0xff << 16)) | ((value as u32) << 16);
+			}
 			0x10001023 => {
-				self.driver_features = (self.driver_features & !(0xff << 24)) | ((value as u32) << 24);
-			},
+				self.driver_features =
+					(self.driver_features & !(0xff << 24)) | ((value as u32) << 24);
+			}
 			0x10001028 => {
 				self.guest_page_size = (self.guest_page_size & !0xff) | (value as u32);
-			},
+			}
 			0x10001029 => {
-				self.guest_page_size = (self.guest_page_size & !(0xff << 8)) | ((value as u32) << 8);
-			},
+				self.guest_page_size =
+					(self.guest_page_size & !(0xff << 8)) | ((value as u32) << 8);
+			}
 			0x1000102a => {
-				self.guest_page_size = (self.guest_page_size & !(0xff << 16)) | ((value as u32) << 16);			
-			},
+				self.guest_page_size =
+					(self.guest_page_size & !(0xff << 16)) | ((value as u32) << 16);
+			}
 			0x1000102b => {
-				self.guest_page_size = (self.guest_page_size & !(0xff << 24)) | ((value as u32) << 24);
-			},
+				self.guest_page_size =
+					(self.guest_page_size & !(0xff << 24)) | ((value as u32) << 24);
+			}
 			0x10001030 => {
 				self.queue_select = (self.queue_select & !0xff) | (value as u32);
-			},
+			}
 			0x10001031 => {
 				self.queue_select = (self.queue_select & !(0xff << 8)) | ((value as u32) << 8);
-			},
+			}
 			0x10001032 => {
-				self.queue_select = (self.queue_select & !(0xff << 16)) | ((value as u32) << 16);			
-			},
+				self.queue_select = (self.queue_select & !(0xff << 16)) | ((value as u32) << 16);
+			}
 			0x10001033 => {
 				self.queue_select = (self.queue_select & !(0xff << 24)) | ((value as u32) << 24);
 				if self.queue_select != 0 {
 					panic!("Virtio: No multi queue support yet.");
 				}
-			},
+			}
 			0x10001038 => {
 				self.queue_size = (self.queue_size & !0xff) | (value as u32);
-			},
+			}
 			0x10001039 => {
 				self.queue_size = (self.queue_size & !(0xff << 8)) | ((value as u32) << 8);
-			},
+			}
 			0x1000103a => {
 				self.queue_size = (self.queue_size & !(0xff << 16)) | ((value as u32) << 16);
-			},
+			}
 			0x1000103b => {
 				self.queue_size = (self.queue_size & !(0xff << 24)) | ((value as u32) << 24);
-			},
+			}
 			0x1000103c => {
 				self.queue_align = (self.queue_align & !0xff) | (value as u32);
-			},
+			}
 			0x1000103d => {
 				self.queue_align = (self.queue_align & !(0xff << 8)) | ((value as u32) << 8);
-			},
+			}
 			0x1000103e => {
-				self.queue_align = (self.queue_align & !(0xff << 16)) | ((value as u32) << 16);			
-			},
+				self.queue_align = (self.queue_align & !(0xff << 16)) | ((value as u32) << 16);
+			}
 			0x1000103f => {
 				self.queue_align = (self.queue_align & !(0xff << 24)) | ((value as u32) << 24);
-			},
+			}
 			0x10001040 => {
 				self.queue_pfn = (self.queue_pfn & !0xff) | (value as u32);
-			},
+			}
 			0x10001041 => {
 				self.queue_pfn = (self.queue_pfn & !(0xff << 8)) | ((value as u32) << 8);
-			},
+			}
 			0x10001042 => {
-				self.queue_pfn = (self.queue_pfn & !(0xff << 16)) | ((value as u32) << 16);			
-			},
+				self.queue_pfn = (self.queue_pfn & !(0xff << 16)) | ((value as u32) << 16);
+			}
 			0x10001043 => {
 				self.queue_pfn = (self.queue_pfn & !(0xff << 24)) | ((value as u32) << 24);
-			},
+			}
 			// @TODO: Queue request support
 			0x10001050 => {
 				self.queue_notify = (self.queue_notify & !0xff) | (value as u32);
-			},
+			}
 			0x10001051 => {
 				self.queue_notify = (self.queue_notify & !(0xff << 8)) | ((value as u32) << 8);
-			},
+			}
 			0x10001052 => {
-				self.queue_notify = (self.queue_notify & !(0xff << 16)) | ((value as u32) << 16);			
-			},
+				self.queue_notify = (self.queue_notify & !(0xff << 16)) | ((value as u32) << 16);
+			}
 			0x10001053 => {
 				self.queue_notify = (self.queue_notify & !(0xff << 24)) | ((value as u32) << 24);
 				self.notify_clocks.push(self.clock);
-			},
+			}
 			0x10001064 => {
 				// interrupt ack
 				if (value & 0x1) == 1 {
@@ -276,19 +293,19 @@ impl VirtioBlockDisk {
 				} else {
 					panic!("Unknown ack {:X}", value);
 				}
-			},
+			}
 			0x10001070 => {
 				self.status = (self.status & !0xff) | (value as u32);
-			},
+			}
 			0x10001071 => {
 				self.status = (self.status & !(0xff << 8)) | ((value as u32) << 8);
-			},
+			}
 			0x10001072 => {
-				self.status = (self.status & !(0xff << 16)) | ((value as u32) << 16);			
-			},
+				self.status = (self.status & !(0xff << 16)) | ((value as u32) << 16);
+			}
 			0x10001073 => {
 				self.status = (self.status & !(0xff << 24)) | ((value as u32) << 24);
-			},
+			}
 			_ => {}
 		};
 	}
@@ -300,10 +317,28 @@ impl VirtioBlockDisk {
 	/// * `mem_addresss` Physical address. Must be eight-byte aligned.
 	/// * `disk_address` Must be eight-byte aligned.
 	/// * `length` Must be eight-byte aligned.
-	fn transfer_from_disk(&mut self, memory: &mut MemoryWrapper, mem_address: u64, disk_address: u64, length: u64) {
-		debug_assert!((mem_address % 8) == 0, "Memory address should be eight-byte aligned. {:X}", mem_address);
-		debug_assert!((disk_address % 8) == 0, "Disk address should be eight-byte aligned. {:X}", disk_address);
-		debug_assert!((length % 8) == 0, "Length should be eight-byte aligned. {:X}", length);
+	fn transfer_from_disk(
+		&mut self,
+		memory: &mut MemoryWrapper,
+		mem_address: u64,
+		disk_address: u64,
+		length: u64,
+	) {
+		debug_assert!(
+			(mem_address % 8) == 0,
+			"Memory address should be eight-byte aligned. {:X}",
+			mem_address
+		);
+		debug_assert!(
+			(disk_address % 8) == 0,
+			"Disk address should be eight-byte aligned. {:X}",
+			disk_address
+		);
+		debug_assert!(
+			(length % 8) == 0,
+			"Length should be eight-byte aligned. {:X}",
+			length
+		);
 		for i in 0..(length / 8) {
 			let disk_index = ((disk_address + i * 8) >> 3) as usize;
 			memory.write_doubleword(mem_address + i * 8, self.contents[disk_index]);
@@ -317,10 +352,28 @@ impl VirtioBlockDisk {
 	/// * `mem_addresss` Physical address. Must be eight-byte aligned.
 	/// * `disk_address` Must be eight-byte aligned.
 	/// * `length` Must be eight-byte aligned.
-	fn transfer_to_disk(&mut self, memory: &mut MemoryWrapper, mem_address: u64, disk_address: u64, length: u64) {
-		debug_assert!((mem_address % 8) == 0, "Memory address should be eight-byte aligned. {:X}", mem_address);
-		debug_assert!((disk_address % 8) == 0, "Disk address should be eight-byte aligned. {:X}", disk_address);
-		debug_assert!((length % 8) == 0, "Length should be eight-byte aligned. {:X}", length);
+	fn transfer_to_disk(
+		&mut self,
+		memory: &mut MemoryWrapper,
+		mem_address: u64,
+		disk_address: u64,
+		length: u64,
+	) {
+		debug_assert!(
+			(mem_address % 8) == 0,
+			"Memory address should be eight-byte aligned. {:X}",
+			mem_address
+		);
+		debug_assert!(
+			(disk_address % 8) == 0,
+			"Disk address should be eight-byte aligned. {:X}",
+			disk_address
+		);
+		debug_assert!(
+			(length % 8) == 0,
+			"Length should be eight-byte aligned. {:X}",
+			length
+		);
 		for i in 0..(length / 8) {
 			let disk_index = ((disk_address + i * 8) >> 3) as usize;
 			self.contents[disk_index] = memory.read_doubleword(mem_address + i * 8);
@@ -408,7 +461,9 @@ impl VirtioBlockDisk {
 
 		let _avail_flag = memory.read_halfword(base_avail_address) as u64;
 		let _avail_index = memory.read_halfword(base_avail_address.wrapping_add(2)) as u64;
-		let desc_index_address = base_avail_address.wrapping_add(4).wrapping_add((self.used_ring_index as u64 % queue_size) * 2);
+		let desc_index_address = base_avail_address
+			.wrapping_add(4)
+			.wrapping_add((self.used_ring_index as u64 % queue_size) * 2);
 		let desc_head_index = (memory.read_halfword(desc_index_address) as u64) % queue_size;
 
 		/*
@@ -431,7 +486,8 @@ impl VirtioBlockDisk {
 			let desc_addr = memory.read_doubleword(desc_element_address);
 			let desc_len = memory.read_word(desc_element_address.wrapping_add(8));
 			let desc_flags = memory.read_halfword(desc_element_address.wrapping_add(12));
-			desc_next = (memory.read_halfword(desc_element_address.wrapping_add(14)) as u64) % queue_size;
+			desc_next =
+				(memory.read_halfword(desc_element_address.wrapping_add(14)) as u64) % queue_size;
 
 			/*
 			println!("Desc addr:{:X}", desc_addr);
@@ -460,27 +516,43 @@ impl VirtioBlockDisk {
 					println!("Blk reserved:{:X}", _blk_reserved);
 					println!("Blk sector:{:X}", blk_sector);
 					*/
-				},
+				}
 				1 => {
 					// Second descriptor: Read/Write disk
 					match (desc_flags & VIRTQ_DESC_F_WRITE) == 0 {
-						true => { // write to disk
-							if (desc_addr % 8) == 0 && ((blk_sector * SECTOR_SIZE) % 8) == 0 &&
-								(desc_len % 8) == 0 {
+						true => {
+							// write to disk
+							if (desc_addr % 8) == 0
+								&& ((blk_sector * SECTOR_SIZE) % 8) == 0
+								&& (desc_len % 8) == 0
+							{
 								// Enter fast path if possible
-								self.transfer_to_disk(memory, desc_addr, blk_sector * SECTOR_SIZE, desc_len as u64);
+								self.transfer_to_disk(
+									memory,
+									desc_addr,
+									blk_sector * SECTOR_SIZE,
+									desc_len as u64,
+								);
 							} else {
 								for i in 0..desc_len as u64 {
 									let data = memory.read_byte(desc_addr + i);
 									self.write_to_disk(blk_sector * SECTOR_SIZE + i, data);
 								}
 							}
-						},
-						false => { // read from disk
-							if (desc_addr % 8) == 0 && ((blk_sector * SECTOR_SIZE) % 8) == 0 &&
-								(desc_len % 8) == 0 {
+						}
+						false => {
+							// read from disk
+							if (desc_addr % 8) == 0
+								&& ((blk_sector * SECTOR_SIZE) % 8) == 0
+								&& (desc_len % 8) == 0
+							{
 								// Enter fast path if possible
-								self.transfer_from_disk(memory, desc_addr, blk_sector * SECTOR_SIZE, desc_len as u64);
+								self.transfer_from_disk(
+									memory,
+									desc_addr,
+									blk_sector * SECTOR_SIZE,
+									desc_len as u64,
+								);
 							} else {
 								for i in 0..desc_len as u64 {
 									let data = self.read_from_disk(blk_sector * SECTOR_SIZE + i);
@@ -489,7 +561,7 @@ impl VirtioBlockDisk {
 							}
 						}
 					};
-				},
+				}
 				2 => {
 					// Third descriptor: Result status
 					if (desc_flags & VIRTQ_DESC_F_WRITE) == 0 {
@@ -499,7 +571,7 @@ impl VirtioBlockDisk {
 						panic!("Third descriptor length should be one.");
 					}
 					memory.write_byte(desc_addr, 0); // 0 means succeeded
-				},
+				}
 				_ => {}
 			};
 
@@ -514,7 +586,12 @@ impl VirtioBlockDisk {
 			panic!("Descript chain length should be three.");
 		}
 
-		memory.write_word(base_used_address.wrapping_add(4).wrapping_add((self.used_ring_index as u64 % queue_size) * 8), desc_head_index as u32);
+		memory.write_word(
+			base_used_address
+				.wrapping_add(4)
+				.wrapping_add((self.used_ring_index as u64 % queue_size) * 8),
+			desc_head_index as u32,
+		);
 
 		self.used_ring_index = self.used_ring_index.wrapping_add(1);
 		memory.write_halfword(base_used_address.wrapping_add(2), self.used_ring_index);

--- a/src/elf_analyzer.rs
+++ b/src/elf_analyzer.rs
@@ -22,7 +22,7 @@ pub struct Header {
 	_e_phnum: u16,
 	_e_shentsize: u16,
 	e_shnum: u16,
-	_e_shstrndx: u16
+	_e_shstrndx: u16,
 }
 
 /// ELF program header
@@ -34,7 +34,7 @@ pub struct _ProgramHeader {
 	_p_paddr: u64,
 	_p_filesz: u64,
 	_p_memsz: u64,
-	_p_align: u64
+	_p_align: u64,
 }
 
 /// ELF section header
@@ -48,7 +48,7 @@ pub struct SectionHeader {
 	_sh_link: u32,
 	_sh_info: u32,
 	_sh_addralign: u64,
-	_sh_entsize: u64
+	_sh_entsize: u64,
 }
 
 /// ELF symbol table entry
@@ -58,12 +58,12 @@ pub struct SymbolEntry {
 	_st_other: u8,
 	_st_shndx: u16,
 	st_value: u64,
-	_st_size: u64
+	_st_size: u64,
 }
 
 /// ELF file analyzer
 pub struct ElfAnalyzer {
-	data: Vec<u8>
+	data: Vec<u8>,
 }
 
 impl ElfAnalyzer {
@@ -72,18 +72,19 @@ impl ElfAnalyzer {
 	/// # Arguments
 	/// * `data` ELF file content binary
 	pub fn new(data: Vec<u8>) -> Self {
-		ElfAnalyzer {
-			data: data
-		}
+		ElfAnalyzer { data: data }
 	}
 
 	/// Checks if ELF file content is valid
 	// @TODO: Validate more precisely
 	pub fn validate(&self) -> bool {
 		// check ELF magic number
-		if self.data.len() < 4 ||
-			self.data[0] != 0x7f || self.data[1] != 0x45 ||
-			self.data[2] != 0x4c || self.data[3] != 0x46 {
+		if self.data.len() < 4
+			|| self.data[0] != 0x7f
+			|| self.data[1] != 0x45
+			|| self.data[2] != 0x4c
+			|| self.data[3] != 0x46
+		{
 			return false;
 		}
 		true
@@ -96,7 +97,7 @@ impl ElfAnalyzer {
 		let e_width = match e_class {
 			1 => 32,
 			2 => 64,
-			_ => panic!("Unknown e_class:{:X}", e_class)
+			_ => panic!("Unknown e_class:{:X}", e_class),
 		};
 
 		let e_endian = self.read_byte(5);
@@ -120,7 +121,7 @@ impl ElfAnalyzer {
 				let data = self.read_doubleword(offset);
 				offset += 8;
 				data
-			},
+			}
 			_ => {
 				let data = self.read_word(offset);
 				offset += 4;
@@ -133,7 +134,7 @@ impl ElfAnalyzer {
 				let data = self.read_doubleword(offset);
 				offset += 8;
 				data
-			},
+			}
 			_ => {
 				let data = self.read_word(offset);
 				offset += 4;
@@ -146,7 +147,7 @@ impl ElfAnalyzer {
 				let data = self.read_doubleword(offset);
 				offset += 8;
 				data
-			},
+			}
 			_ => {
 				let data = self.read_word(offset);
 				offset += 4;
@@ -215,7 +216,7 @@ impl ElfAnalyzer {
 			_e_phnum: e_phnum,
 			_e_shentsize: e_shentsize,
 			e_shnum: e_shnum,
-			_e_shstrndx: e_shstrndx
+			_e_shstrndx: e_shstrndx,
 		}
 	}
 
@@ -241,13 +242,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let p_vaddr = match header.e_width {
@@ -255,13 +256,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let p_paddr = match header.e_width {
@@ -269,13 +270,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let p_filesz = match header.e_width {
@@ -283,13 +284,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let p_memsz = match header.e_width {
@@ -297,13 +298,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			if header.e_width == 32 {
@@ -316,13 +317,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			/*
@@ -339,7 +340,7 @@ impl ElfAnalyzer {
 			println!("p_align:{:X}", p_align);
 			*/
 
-			headers.push(_ProgramHeader{
+			headers.push(_ProgramHeader {
 				_p_type: p_type,
 				_p_flags: p_flags,
 				_p_offset: p_offset,
@@ -347,7 +348,7 @@ impl ElfAnalyzer {
 				_p_paddr: p_paddr,
 				_p_filesz: p_filesz,
 				_p_memsz: p_memsz,
-				_p_align: p_align
+				_p_align: p_align,
 			});
 		}
 
@@ -373,13 +374,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let sh_addr = match header.e_width {
@@ -387,13 +388,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let sh_offset = match header.e_width {
@@ -401,13 +402,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let sh_size = match header.e_width {
@@ -415,13 +416,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let sh_link = self.read_word(offset);
@@ -435,13 +436,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			let sh_entsize = match header.e_width {
@@ -449,13 +450,13 @@ impl ElfAnalyzer {
 					let data = self.read_doubleword(offset);
 					offset += 8;
 					data
-				},
+				}
 				32 => {
 					let data = self.read_word(offset);
 					offset += 4;
 					data as u64
-				},
-				_ => panic!("Not happen")
+				}
+				_ => panic!("Not happen"),
 			};
 
 			/*
@@ -483,7 +484,7 @@ impl ElfAnalyzer {
 				_sh_link: sh_link,
 				_sh_info: sh_info,
 				_sh_addralign: sh_addralign,
-				_sh_entsize: sh_entsize
+				_sh_entsize: sh_entsize,
 			});
 		}
 
@@ -495,9 +496,11 @@ impl ElfAnalyzer {
 	/// # Arguments
 	/// * `Terminal`
 	/// * `symbol_table_section_headers`
-	pub fn read_symbol_entries(&self, header: &Header,
-		symbol_table_section_headers: &Vec<&SectionHeader>)
-		-> Vec<SymbolEntry> {
+	pub fn read_symbol_entries(
+		&self,
+		header: &Header,
+		symbol_table_section_headers: &Vec<&SectionHeader>,
+	) -> Vec<SymbolEntry> {
 		let mut entries = Vec::new();
 		for i in 0..symbol_table_section_headers.len() {
 			let sh_offset = symbol_table_section_headers[i].sh_offset;
@@ -508,7 +511,7 @@ impl ElfAnalyzer {
 			let entry_size = match header.e_width {
 				64 => 24,
 				32 => 16,
-				_ => panic!("Not happen")
+				_ => panic!("Not happen"),
 			};
 
 			for _j in 0..(sh_size / entry_size) {
@@ -538,7 +541,7 @@ impl ElfAnalyzer {
 
 						_st_size = self.read_doubleword(offset);
 						offset += 8;
-					},
+					}
 					32 => {
 						st_name = self.read_word(offset);
 						offset += 4;
@@ -557,8 +560,8 @@ impl ElfAnalyzer {
 
 						_st_shndx = self.read_halfword(offset);
 						offset += 2;
-					},
-					_ => panic!("No happen")
+					}
+					_ => panic!("No happen"),
 				};
 
 				/*
@@ -572,13 +575,13 @@ impl ElfAnalyzer {
 				println!("");
 				*/
 
-				entries.push(SymbolEntry{
+				entries.push(SymbolEntry {
 					st_name: st_name,
 					st_info: st_info,
 					_st_other: _st_other,
 					_st_shndx: _st_shndx,
 					st_value: st_value,
-					_st_size: _st_size
+					_st_size: _st_size,
 				});
 			}
 		}
@@ -616,8 +619,11 @@ impl ElfAnalyzer {
 	/// # Arguments
 	/// * `entries` Symbol entries
 	/// * `string_table_section_header` The header of the string table section
-	pub fn create_symbol_map(&self, entries: &Vec<SymbolEntry>,
-		string_table_section_header: &SectionHeader) -> FnvHashMap<String, u64> {
+	pub fn create_symbol_map(
+		&self,
+		entries: &Vec<SymbolEntry>,
+		string_table_section_header: &SectionHeader,
+	) -> FnvHashMap<String, u64> {
 		let mut map = FnvHashMap::default();
 		for i in 0..entries.len() {
 			let st_info = entries[i].st_info;
@@ -645,9 +651,11 @@ impl ElfAnalyzer {
 	/// # Arguments
 	/// * `program_data_section_headers`
 	/// * `string_table_section_headers`
-	pub fn find_tohost_addr(&self, program_data_section_headers: &Vec<&SectionHeader>,
-		string_table_section_headers: &Vec<&SectionHeader>)
-		-> Option<u64> {
+	pub fn find_tohost_addr(
+		&self,
+		program_data_section_headers: &Vec<&SectionHeader>,
+		string_table_section_headers: &Vec<&SectionHeader>,
+	) -> Option<u64> {
 		let tohost_values = vec![0x2e, 0x74, 0x6f, 0x68, 0x6f, 0x73, 0x74, 0x00]; // ".tohost\null"
 		for i in 0..program_data_section_headers.len() {
 			let sh_addr = program_data_section_headers[i].sh_addr;
@@ -661,7 +669,9 @@ impl ElfAnalyzer {
 				let mut found = true;
 				for k in 0..tohost_values.len() as u64 {
 					let addr = sh_offset + sh_name + k;
-					if addr >= sh_offset + sh_size || self.read_byte(addr as usize) != tohost_values[k as usize] {
+					if addr >= sh_offset + sh_size
+						|| self.read_byte(addr as usize) != tohost_values[k as usize]
+					{
 						found = false;
 						break;
 					}

--- a/src/elf_analyzer.rs
+++ b/src/elf_analyzer.rs
@@ -645,45 +645,6 @@ impl ElfAnalyzer {
 		map
 	}
 
-	/// Finds a program data section whose name is .tohost. If found this method
-	/// returns an address of the section.
-	///
-	/// # Arguments
-	/// * `program_data_section_headers`
-	/// * `string_table_section_headers`
-	pub fn find_tohost_addr(
-		&self,
-		program_data_section_headers: &Vec<&SectionHeader>,
-		string_table_section_headers: &Vec<&SectionHeader>,
-	) -> Option<u64> {
-		let tohost_values = vec![0x2e, 0x74, 0x6f, 0x68, 0x6f, 0x73, 0x74, 0x00]; // ".tohost\null"
-		for i in 0..program_data_section_headers.len() {
-			let sh_addr = program_data_section_headers[i].sh_addr;
-			let sh_name = program_data_section_headers[i].sh_name as u64;
-			// Find all string sections so far.
-			// @TODO: Is there a way to know which string table section
-			//        sh_name of program data section points to?
-			for j in 0..string_table_section_headers.len() {
-				let sh_offset = string_table_section_headers[j].sh_offset;
-				let sh_size = string_table_section_headers[j].sh_size;
-				let mut found = true;
-				for k in 0..tohost_values.len() as u64 {
-					let addr = sh_offset + sh_name + k;
-					if addr >= sh_offset + sh_size
-						|| self.read_byte(addr as usize) != tohost_values[k as usize]
-					{
-						found = false;
-						break;
-					}
-				}
-				if found {
-					return Some(sh_addr);
-				}
-			}
-		}
-		None
-	}
-
 	/// Reads a byte from ELF file content
 	///
 	/// # Arguments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // @TODO: temporal
-const TEST_MEMORY_CAPACITY: u64 = 1024 * 512;
+const TEST_MEMORY_CAPACITY: u64 = 1024 * 512 * 10;
 const PROGRAM_MEMORY_CAPACITY: u64 = 1024 * 1024 * 128; // big enough to run Linux and xv6
 
 extern crate fnv;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ use cpu::{Cpu, Xlen};
 use elf_analyzer::ElfAnalyzer;
 use terminal::Terminal;
 
+use std::io::Write;
+
 /// RISC-V emulator. It emulates RISC-V CPU and peripheral devices.
 ///
 /// Sample code to run the emulator.
@@ -45,6 +47,15 @@ pub struct Emulator {
 	/// [`riscv-tests`](https://github.com/riscv/riscv-tests) specific properties.
 	/// The address where data will be sent to terminal
 	tohost_addr: u64,
+
+	/// In RISC-V testing, signatures are memory-stored execution results. They're
+	/// used to compare a processor's behavior against a trusted reference model
+	/// (like SAIL or Spike) to ensure correct and compliant operation.
+	/// The address where the signature region begins
+	pub begin_signature_addr: u64,
+
+	/// The address where the signature region ends
+	pub end_signature_addr: u64,
 }
 
 impl Emulator {
@@ -62,6 +73,8 @@ impl Emulator {
 			// These can be updated in setup_program()
 			is_test: false,
 			tohost_addr: 0, // assuming tohost_addr is non-zero if exists
+			begin_signature_addr: 0,
+			end_signature_addr: 0,
 		}
 	}
 
@@ -97,23 +110,30 @@ impl Emulator {
 
 			self.tick();
 
-			// It seems in riscv-tests ends with end code
-			// written to a certain physical memory address
-			// (0x80001000 in mose test cases) so checking
-			// the data in the address and terminating the test
-			// if non-zero data is written.
-			// End code 1 seems to mean pass.
-			let endcode = self.cpu.get_mut_mmu().load_word_raw(self.tohost_addr);
-			if endcode != 0 {
-				match endcode {
-					1 => self.put_bytes_to_terminal(
-						format!("Test Passed with {:X}\n", endcode).as_bytes(),
-					),
-					_ => self.put_bytes_to_terminal(
-						format!("Test Failed with {:X}\n", endcode).as_bytes(),
-					),
-				};
-				break;
+			// Check if tohost has been written to
+			let tohost_value = self.cpu.get_mut_mmu().load_doubleword_raw(self.tohost_addr);
+			if tohost_value != 0 {
+				// Extract device, cmd and payload from tohost value
+				// Format matches sail-riscv's htif_cmd bitfield:
+				// device  : 63 .. 56
+				// cmd     : 55 .. 48
+				// payload : 47 .. 0
+				let device = (tohost_value >> 56) & 0xFF;
+				let _cmd = (tohost_value >> 48) & 0xFF;
+				let payload = tohost_value & 0xFFFFFFFFFFFF;
+
+				// Check if this is a syscall-proxy command (device 0x00)
+				// and if the LSB of payload is set (indicating program done)
+				if device == 0x00 && (payload & 1) == 1 {
+					// Extract exit code by shifting payload right by 1
+					let exit_code = payload >> 1;
+					if exit_code == 0 {
+						self.put_bytes_to_terminal(b"SUCCESS\n");
+					} else {
+						self.put_bytes_to_terminal(format!("FAILURE: {exit_code}\n").as_bytes());
+					}
+					break;
+				}
 			}
 		}
 	}
@@ -165,14 +185,6 @@ impl Emulator {
 			};
 		}
 
-		// Find program data section named .tohost to detect if the elf file is riscv-tests
-		self.tohost_addr = match analyzer
-			.find_tohost_addr(&program_data_section_headers, &string_table_section_headers)
-		{
-			Some(address) => address,
-			None => 0,
-		};
-
 		// Creates symbol - virtual address mapping
 		if string_table_section_headers.len() > 0 {
 			let entries = analyzer.read_symbol_entries(&header, &symbol_table_section_headers);
@@ -184,6 +196,11 @@ impl Emulator {
 					.insert(key.to_string(), *map.get(key).unwrap());
 			}
 		}
+
+		// Find tohost, begin_signature, and end_signature addresses from symbol map since they are all global labels
+		self.tohost_addr = self.symbol_map.get("tohost").copied().unwrap_or(0);
+		self.begin_signature_addr = self.symbol_map.get("begin_signature").copied().unwrap_or(0);
+		self.end_signature_addr = self.symbol_map.get("end_signature").copied().unwrap_or(0);
 
 		// Detected whether the elf file is riscv-tests.
 		// Setting up CPU and Memory depending on it.
@@ -319,6 +336,34 @@ impl Emulator {
 			Some(address) => Some(*address),
 			None => None,
 		}
+	}
+
+	/// Writes the signature region to a writer with specified granularity.
+	/// The signature is written in little-endian byte order.
+	///
+	/// # Arguments
+	/// * `writer` - Any type that implements Write trait
+	/// * `granularity` - Number of bytes to write per line (must be a power of 2)
+	///
+	/// # Returns
+	/// * `Result<(), std::io::Error>` - Ok if successful, Err if write operations fail
+	pub fn write_signature<W: Write>(
+		&mut self,
+		writer: &mut W,
+		granularity: usize,
+	) -> std::io::Result<()> {
+		if self.begin_signature_addr == 0 || self.end_signature_addr == 0 {
+			return Ok(());
+		}
+
+		for addr in (self.begin_signature_addr..self.end_signature_addr).step_by(granularity) {
+			// Load word and write in big-endian order
+			let word = self.cpu.get_mut_mmu().load_word_raw(addr);
+			write!(writer, "{word:08x}")?;
+			writeln!(writer)?;
+		}
+
+		Ok(())
 	}
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,15 +1,13 @@
 /// Emulates main memory.
 pub struct Memory {
 	/// Memory content
-	data: Vec<u64>
+	data: Vec<u64>,
 }
 
 impl Memory {
 	/// Creates a new `Memory`
 	pub fn new() -> Self {
-		Memory {
-			data: vec![]
-		}
+		Memory { data: vec![] }
 	}
 
 	/// Initializes memory content.
@@ -22,7 +20,7 @@ impl Memory {
 			self.data.push(0);
 		}
 	}
-	
+
 	/// Reads a byte from memory.
 	///
 	/// # Arguments
@@ -70,7 +68,8 @@ impl Memory {
 			let index = (address >> 3) as usize;
 			self.data[index]
 		} else if (address % 4) == 0 {
-			(self.read_word(address) as u64) | ((self.read_word(address.wrapping_add(4)) as u64) << 4)
+			(self.read_word(address) as u64)
+				| ((self.read_word(address.wrapping_add(4)) as u64) << 4)
 		} else {
 			self.read_bytes(address, 8)
 		}
@@ -164,6 +163,6 @@ impl Memory {
 	/// # Arguments
 	/// * `address`
 	pub fn validate_address(&self, address: u64) -> bool {
-		return (address as usize) < self.data.len()
+		return (address as usize) < self.data.len();
 	}
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -163,6 +163,7 @@ impl Memory {
 	/// # Arguments
 	/// * `address`
 	pub fn validate_address(&self, address: u64) -> bool {
-		return (address as usize) < self.data.len();
+		let word_index = (address >> 3) as usize;
+		word_index < self.data.len()
 	}
 }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -466,7 +466,7 @@ impl Mmu {
 	///
 	/// # Arguments
 	/// * `p_address` Physical address
-	fn load_raw(&mut self, p_address: u64) -> u8 {
+	pub fn load_raw(&mut self, p_address: u64) -> u8 {
 		let effective_address = self.get_effective_address(p_address);
 		// @TODO: Mapping should be configurable with dtb
 		match effective_address >= DRAM_BASE {
@@ -534,7 +534,7 @@ impl Mmu {
 	///
 	/// # Arguments
 	/// * `p_address` Physical address
-	fn load_doubleword_raw(&mut self, p_address: u64) -> u64 {
+	pub fn load_doubleword_raw(&mut self, p_address: u64) -> u64 {
 		let effective_address = self.get_effective_address(p_address);
 		match effective_address >= DRAM_BASE
 			&& effective_address.wrapping_add(7) > effective_address

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -8,12 +8,12 @@ extern crate fnv;
 
 use self::fnv::FnvHashMap;
 
-use memory::Memory;
-use cpu::{PrivilegeMode, Trap, TrapType, Xlen, get_privilege_mode};
-use device::virtio_block_disk::VirtioBlockDisk;
-use device::plic::Plic;
+use cpu::{get_privilege_mode, PrivilegeMode, Trap, TrapType, Xlen};
 use device::clint::Clint;
+use device::plic::Plic;
 use device::uart::Uart;
+use device::virtio_block_disk::VirtioBlockDisk;
+use memory::Memory;
 use terminal::Terminal;
 
 /// Emulates Memory Management Unit. It holds the Main memory and peripheral
@@ -52,21 +52,21 @@ pub struct Mmu {
 	page_cache_enabled: bool,
 	fetch_page_cache: FnvHashMap<u64, u64>,
 	load_page_cache: FnvHashMap<u64, u64>,
-	store_page_cache: FnvHashMap<u64, u64>
+	store_page_cache: FnvHashMap<u64, u64>,
 }
 
 pub enum AddressingMode {
 	None,
 	SV32,
 	SV39,
-	SV48 // @TODO: Implement
+	SV48, // @TODO: Implement
 }
 
 enum MemoryAccessType {
 	Execute,
 	Read,
 	Write,
-	DontCare
+	DontCare,
 }
 
 fn _get_addressing_mode_name(mode: &AddressingMode) -> &'static str {
@@ -74,7 +74,7 @@ fn _get_addressing_mode_name(mode: &AddressingMode) -> &'static str {
 		AddressingMode::None => "None",
 		AddressingMode::SV32 => "SV32",
 		AddressingMode::SV39 => "SV39",
-		AddressingMode::SV48 => "SV48"
+		AddressingMode::SV48 => "SV48",
 	}
 }
 
@@ -109,7 +109,7 @@ impl Mmu {
 			page_cache_enabled: false,
 			fetch_page_cache: FnvHashMap::default(),
 			load_page_cache: FnvHashMap::default(),
-			store_page_cache: FnvHashMap::default()
+			store_page_cache: FnvHashMap::default(),
 		}
 	}
 
@@ -129,7 +129,7 @@ impl Mmu {
 	pub fn init_memory(&mut self, capacity: u64) {
 		self.memory.init(capacity);
 	}
-	
+
 	/// Initializes Virtio block disk. This method is expected to be called only once.
 	///
 	/// # Arguments
@@ -172,7 +172,11 @@ impl Mmu {
 		self.clint.tick(mip);
 		self.disk.tick(&mut self.memory);
 		self.uart.tick();
-		self.plic.tick(self.disk.is_interrupting(), self.uart.is_interrupting(), mip);
+		self.plic.tick(
+			self.disk.is_interrupting(),
+			self.uart.is_interrupting(),
+			mip,
+		);
 		self.clock = self.clock.wrapping_add(1);
 	}
 
@@ -215,7 +219,7 @@ impl Mmu {
 	fn get_effective_address(&self, address: u64) -> u64 {
 		match self.xlen {
 			Xlen::Bit32 => address & 0xffffffff,
-			Xlen::Bit64 => address
+			Xlen::Bit64 => address,
 		}
 	}
 
@@ -227,10 +231,12 @@ impl Mmu {
 	fn fetch(&mut self, v_address: u64) -> Result<u8, Trap> {
 		match self.translate_address(v_address, &MemoryAccessType::Execute) {
 			Ok(p_address) => Ok(self.load_raw(p_address)),
-			Err(()) => return Err(Trap {
-				trap_type: TrapType::InstructionPageFault,
-				value: v_address
-			})
+			Err(()) => {
+				return Err(Trap {
+					trap_type: TrapType::InstructionPageFault,
+					value: v_address,
+				})
+			}
 		}
 	}
 
@@ -250,18 +256,16 @@ impl Mmu {
 					Ok(p_address) => Ok(self.load_word_raw(p_address)),
 					Err(()) => Err(Trap {
 						trap_type: TrapType::InstructionPageFault,
-						value: effective_address
-					})
+						value: effective_address,
+					}),
 				}
-			},
+			}
 			false => {
 				let mut data = 0 as u32;
 				for i in 0..width {
 					match self.fetch(v_address.wrapping_add(i)) {
-						Ok(byte) => {
-							data |= (byte as u32) << (i * 8)
-						},
-						Err(e) => return Err(e)
+						Ok(byte) => data |= (byte as u32) << (i * 8),
+						Err(e) => return Err(e),
 					};
 				}
 				Ok(data)
@@ -280,8 +284,8 @@ impl Mmu {
 			Ok(p_address) => Ok(self.load_raw(p_address)),
 			Err(()) => Err(Trap {
 				trap_type: TrapType::LoadPageFault,
-				value: v_address
-			})
+				value: v_address,
+			}),
 		}
 	}
 
@@ -292,8 +296,11 @@ impl Mmu {
 	/// * `v_address` Virtual address
 	/// * `width` Must be 1, 2, 4, or 8
 	fn load_bytes(&mut self, v_address: u64, width: u64) -> Result<u64, Trap> {
-		debug_assert!(width == 1 || width == 2 || width == 4 || width == 8,
-			"Width must be 1, 2, 4, or 8. {:X}", width);
+		debug_assert!(
+			width == 1 || width == 2 || width == 4 || width == 8,
+			"Width must be 1, 2, 4, or 8. {:X}",
+			width
+		);
 		match (v_address & 0xfff) <= (0x1000 - width) {
 			true => match self.translate_address(v_address, &MemoryAccessType::Read) {
 				Ok(p_address) => {
@@ -304,22 +311,20 @@ impl Mmu {
 						2 => Ok(self.load_halfword_raw(p_address) as u64),
 						4 => Ok(self.load_word_raw(p_address) as u64),
 						8 => Ok(self.load_doubleword_raw(p_address)),
-						_ => panic!("Width must be 1, 2, 4, or 8. {:X}", width)
+						_ => panic!("Width must be 1, 2, 4, or 8. {:X}", width),
 					}
-				},
+				}
 				Err(()) => Err(Trap {
 					trap_type: TrapType::LoadPageFault,
-					value: v_address
-				})
+					value: v_address,
+				}),
 			},
 			false => {
 				let mut data = 0 as u64;
 				for i in 0..width {
 					match self.load(v_address.wrapping_add(i)) {
-						Ok(byte) => {
-							data |= (byte as u64) << (i * 8)
-						},
-						Err(e) => return Err(e)
+						Ok(byte) => data |= (byte as u64) << (i * 8),
+						Err(e) => return Err(e),
 					};
 				}
 				Ok(data)
@@ -335,7 +340,7 @@ impl Mmu {
 	pub fn load_halfword(&mut self, v_address: u64) -> Result<u16, Trap> {
 		match self.load_bytes(v_address, 2) {
 			Ok(data) => Ok(data as u16),
-			Err(e) => Err(e)
+			Err(e) => Err(e),
 		}
 	}
 
@@ -347,7 +352,7 @@ impl Mmu {
 	pub fn load_word(&mut self, v_address: u64) -> Result<u32, Trap> {
 		match self.load_bytes(v_address, 4) {
 			Ok(data) => Ok(data as u32),
-			Err(e) => Err(e)
+			Err(e) => Err(e),
 		}
 	}
 
@@ -359,7 +364,7 @@ impl Mmu {
 	pub fn load_doubleword(&mut self, v_address: u64) -> Result<u64, Trap> {
 		match self.load_bytes(v_address, 8) {
 			Ok(data) => Ok(data as u64),
-			Err(e) => Err(e)
+			Err(e) => Err(e),
 		}
 	}
 
@@ -374,11 +379,11 @@ impl Mmu {
 			Ok(p_address) => {
 				self.store_raw(p_address, value);
 				Ok(())
-			},
+			}
 			Err(()) => Err(Trap {
 				trap_type: TrapType::StorePageFault,
-				value: v_address
-			})
+				value: v_address,
+			}),
 		}
 	}
 
@@ -390,8 +395,11 @@ impl Mmu {
 	/// * `value` data written
 	/// * `width` Must be 1, 2, 4, or 8
 	fn store_bytes(&mut self, v_address: u64, value: u64, width: u64) -> Result<(), Trap> {
-		debug_assert!(width == 1 || width == 2 || width == 4 || width == 8,
-			"Width must be 1, 2, 4, or 8. {:X}", width);
+		debug_assert!(
+			width == 1 || width == 2 || width == 4 || width == 8,
+			"Width must be 1, 2, 4, or 8. {:X}",
+			width
+		);
 		match (v_address & 0xfff) <= (0x1000 - width) {
 			true => match self.translate_address(v_address, &MemoryAccessType::Write) {
 				Ok(p_address) => {
@@ -402,20 +410,20 @@ impl Mmu {
 						2 => self.store_halfword_raw(p_address, value as u16),
 						4 => self.store_word_raw(p_address, value as u32),
 						8 => self.store_doubleword_raw(p_address, value),
-						_ => panic!("Width must be 1, 2, 4, or 8. {:X}", width)
+						_ => panic!("Width must be 1, 2, 4, or 8. {:X}", width),
 					}
 					Ok(())
-				},
+				}
 				Err(()) => Err(Trap {
 					trap_type: TrapType::StorePageFault,
-					value: v_address
-				})
+					value: v_address,
+				}),
 			},
 			false => {
 				for i in 0..width {
 					match self.store(v_address.wrapping_add(i), ((value >> (i * 8)) & 0xff) as u8) {
-						Ok(()) => {},
-						Err(e) => return Err(e)
+						Ok(()) => {}
+						Err(e) => return Err(e),
 					}
 				}
 				Ok(())
@@ -472,8 +480,8 @@ impl Mmu {
 				0x0C000000..=0x0fffffff => self.plic.load(effective_address),
 				0x10000000..=0x100000ff => self.uart.load(effective_address),
 				0x10001000..=0x10001FFF => self.disk.load(effective_address),
-				_ => panic!("Unknown memory mapping {:X}.", effective_address)
-			}
+				_ => panic!("Unknown memory mapping {:X}.", effective_address),
+			},
 		}
 	}
 
@@ -484,7 +492,9 @@ impl Mmu {
 	/// * `p_address` Physical address
 	fn load_halfword_raw(&mut self, p_address: u64) -> u16 {
 		let effective_address = self.get_effective_address(p_address);
-		match effective_address >= DRAM_BASE && effective_address.wrapping_add(1) > effective_address {
+		match effective_address >= DRAM_BASE
+			&& effective_address.wrapping_add(1) > effective_address
+		{
 			// Fast path. Directly load main memory at a time.
 			true => self.memory.read_halfword(effective_address),
 			false => {
@@ -504,7 +514,9 @@ impl Mmu {
 	/// * `p_address` Physical address
 	pub fn load_word_raw(&mut self, p_address: u64) -> u32 {
 		let effective_address = self.get_effective_address(p_address);
-		match effective_address >= DRAM_BASE && effective_address.wrapping_add(3) > effective_address {
+		match effective_address >= DRAM_BASE
+			&& effective_address.wrapping_add(3) > effective_address
+		{
 			// Fast path. Directly load main memory at a time.
 			true => self.memory.read_word(effective_address),
 			false => {
@@ -524,7 +536,9 @@ impl Mmu {
 	/// * `p_address` Physical address
 	fn load_doubleword_raw(&mut self, p_address: u64) -> u64 {
 		let effective_address = self.get_effective_address(p_address);
-		match effective_address >= DRAM_BASE && effective_address.wrapping_add(7) > effective_address {
+		match effective_address >= DRAM_BASE
+			&& effective_address.wrapping_add(7) > effective_address
+		{
 			// Fast path. Directly load main memory at a time.
 			true => self.memory.read_doubleword(effective_address),
 			false => {
@@ -553,8 +567,8 @@ impl Mmu {
 				0x0c000000..=0x0fffffff => self.plic.store(effective_address, value),
 				0x10000000..=0x100000ff => self.uart.store(effective_address, value),
 				0x10001000..=0x10001FFF => self.disk.store(effective_address, value),
-				_ => panic!("Unknown memory mapping {:X}.", effective_address)
-			}
+				_ => panic!("Unknown memory mapping {:X}.", effective_address),
+			},
 		};
 	}
 
@@ -566,12 +580,17 @@ impl Mmu {
 	/// * `value` data written
 	fn store_halfword_raw(&mut self, p_address: u64, value: u16) {
 		let effective_address = self.get_effective_address(p_address);
-		match effective_address >= DRAM_BASE && effective_address.wrapping_add(1) > effective_address {
+		match effective_address >= DRAM_BASE
+			&& effective_address.wrapping_add(1) > effective_address
+		{
 			// Fast path. Directly store to main memory at a time.
 			true => self.memory.write_halfword(effective_address, value),
 			false => {
 				for i in 0..2 {
-					self.store_raw(effective_address.wrapping_add(i), ((value >> (i * 8)) & 0xff) as u8);
+					self.store_raw(
+						effective_address.wrapping_add(i),
+						((value >> (i * 8)) & 0xff) as u8,
+					);
 				}
 			}
 		}
@@ -585,12 +604,17 @@ impl Mmu {
 	/// * `value` data written
 	fn store_word_raw(&mut self, p_address: u64, value: u32) {
 		let effective_address = self.get_effective_address(p_address);
-		match effective_address >= DRAM_BASE && effective_address.wrapping_add(3) > effective_address {
+		match effective_address >= DRAM_BASE
+			&& effective_address.wrapping_add(3) > effective_address
+		{
 			// Fast path. Directly store to main memory at a time.
 			true => self.memory.write_word(effective_address, value),
 			false => {
 				for i in 0..4 {
-					self.store_raw(effective_address.wrapping_add(i), ((value >> (i * 8)) & 0xff) as u8);
+					self.store_raw(
+						effective_address.wrapping_add(i),
+						((value >> (i * 8)) & 0xff) as u8,
+					);
 				}
 			}
 		}
@@ -604,12 +628,17 @@ impl Mmu {
 	/// * `value` data written
 	fn store_doubleword_raw(&mut self, p_address: u64, value: u64) {
 		let effective_address = self.get_effective_address(p_address);
-		match effective_address >= DRAM_BASE && effective_address.wrapping_add(7) > effective_address {
+		match effective_address >= DRAM_BASE
+			&& effective_address.wrapping_add(7) > effective_address
+		{
 			// Fast path. Directly store to main memory at a time.
 			true => self.memory.write_doubleword(effective_address, value),
 			false => {
 				for i in 0..8 {
-					self.store_raw(effective_address.wrapping_add(i), ((value >> (i * 8)) & 0xff) as u8);
+					self.store_raw(
+						effective_address.wrapping_add(i),
+						((value >> (i * 8)) & 0xff) as u8,
+					);
 				}
 			}
 		}
@@ -624,7 +653,7 @@ impl Mmu {
 		// @TODO: Support other access types?
 		let p_address = match self.translate_address(v_address, &MemoryAccessType::DontCare) {
 			Ok(address) => address,
-			Err(()) => return Err(())
+			Err(()) => return Err(()),
 		};
 		let effective_address = self.get_effective_address(p_address);
 		let valid = match effective_address >= DRAM_BASE {
@@ -635,13 +664,17 @@ impl Mmu {
 				0x0C000000..=0x0fffffff => true,
 				0x10000000..=0x100000ff => true,
 				0x10001000..=0x10001FFF => true,
-				_ => false
-			}
+				_ => false,
+			},
 		};
 		Ok(valid)
 	}
 
-	fn translate_address(&mut self, v_address: u64, access_type: &MemoryAccessType) -> Result<u64, ()> {
+	fn translate_address(
+		&mut self,
+		v_address: u64,
+		access_type: &MemoryAccessType,
+	) -> Result<u64, ()> {
 		let address = self.get_effective_address(v_address);
 		let v_page = address & !0xfff;
 		let cache = match self.page_cache_enabled {
@@ -651,7 +684,7 @@ impl Mmu {
 				MemoryAccessType::Write => self.store_page_cache.get(&v_page),
 				MemoryAccessType::DontCare => None,
 			},
-			false => None
+			false => None,
 		};
 		match cache {
 			Some(p_page) => Ok(p_page | (address & 0xfff)),
@@ -666,25 +699,28 @@ impl Mmu {
 							_ => match (self.mstatus >> 17) & 1 {
 								0 => Ok(address),
 								_ => {
-									let privilege_mode = get_privilege_mode((self.mstatus >> 9) & 3);
+									let privilege_mode =
+										get_privilege_mode((self.mstatus >> 9) & 3);
 									match privilege_mode {
 										PrivilegeMode::Machine => Ok(address),
 										_ => {
-											let current_privilege_mode = self.privilege_mode.clone();
+											let current_privilege_mode =
+												self.privilege_mode.clone();
 											self.update_privilege_mode(privilege_mode);
-											let result = self.translate_address(v_address, access_type);
+											let result =
+												self.translate_address(v_address, access_type);
 											self.update_privilege_mode(current_privilege_mode);
 											result
 										}
 									}
 								}
-							}
+							},
 						},
 						PrivilegeMode::User | PrivilegeMode::Supervisor => {
 							let vpns = [(address >> 12) & 0x3ff, (address >> 22) & 0x3ff];
 							self.traverse_page(address, 2 - 1, self.ppn, &vpns, &access_type)
-						},
-						_ => Ok(address)
+						}
+						_ => Ok(address),
 					},
 					AddressingMode::SV39 => match self.privilege_mode {
 						// @TODO: Optimize
@@ -695,25 +731,32 @@ impl Mmu {
 							_ => match (self.mstatus >> 17) & 1 {
 								0 => Ok(address),
 								_ => {
-									let privilege_mode = get_privilege_mode((self.mstatus >> 9) & 3);
+									let privilege_mode =
+										get_privilege_mode((self.mstatus >> 9) & 3);
 									match privilege_mode {
 										PrivilegeMode::Machine => Ok(address),
 										_ => {
-											let current_privilege_mode = self.privilege_mode.clone();
+											let current_privilege_mode =
+												self.privilege_mode.clone();
 											self.update_privilege_mode(privilege_mode);
-											let result = self.translate_address(v_address, access_type);
+											let result =
+												self.translate_address(v_address, access_type);
 											self.update_privilege_mode(current_privilege_mode);
 											result
 										}
 									}
 								}
-							}
+							},
 						},
 						PrivilegeMode::User | PrivilegeMode::Supervisor => {
-							let vpns = [(address >> 12) & 0x1ff, (address >> 21) & 0x1ff, (address >> 30) & 0x1ff];
+							let vpns = [
+								(address >> 12) & 0x1ff,
+								(address >> 21) & 0x1ff,
+								(address >> 30) & 0x1ff,
+							];
 							self.traverse_page(address, 3 - 1, self.ppn, &vpns, &access_type)
-						},
-						_ => Ok(address)
+						}
+						_ => Ok(address),
 					},
 					AddressingMode::SV48 => {
 						panic!("AddressingMode SV48 is not supported yet.");
@@ -724,41 +767,57 @@ impl Mmu {
 						Ok(p_address) => {
 							let p_page = p_address & !0xfff;
 							match access_type {
-								MemoryAccessType::Execute => self.fetch_page_cache.insert(v_page, p_page),
-								MemoryAccessType::Read => self.load_page_cache.insert(v_page, p_page),
-								MemoryAccessType::Write => self.store_page_cache.insert(v_page, p_page),
+								MemoryAccessType::Execute => {
+									self.fetch_page_cache.insert(v_page, p_page)
+								}
+								MemoryAccessType::Read => {
+									self.load_page_cache.insert(v_page, p_page)
+								}
+								MemoryAccessType::Write => {
+									self.store_page_cache.insert(v_page, p_page)
+								}
 								MemoryAccessType::DontCare => None,
 							};
 							Ok(p_address)
-						},
-						Err(()) => Err(())
+						}
+						Err(()) => Err(()),
 					},
-					false => p_address
+					false => p_address,
 				}
 			}
 		}
 	}
 
-	fn traverse_page(&mut self, v_address: u64, level: u8, parent_ppn: u64,
-		vpns: &[u64], access_type: &MemoryAccessType) -> Result<u64, ()> {
+	fn traverse_page(
+		&mut self,
+		v_address: u64,
+		level: u8,
+		parent_ppn: u64,
+		vpns: &[u64],
+		access_type: &MemoryAccessType,
+	) -> Result<u64, ()> {
 		let pagesize = 4096;
 		let ptesize = match self.addressing_mode {
 			AddressingMode::SV32 => 4,
-			_ => 8
+			_ => 8,
 		};
 		let pte_address = parent_ppn * pagesize + vpns[level as usize] * ptesize;
 		let pte = match self.addressing_mode {
 			AddressingMode::SV32 => self.load_word_raw(pte_address) as u64,
-			_ => self.load_doubleword_raw(pte_address)
+			_ => self.load_doubleword_raw(pte_address),
 		};
 		let ppn = match self.addressing_mode {
 			AddressingMode::SV32 => (pte >> 10) & 0x3fffff,
-			_ => (pte >> 10) & 0xfffffffffff
+			_ => (pte >> 10) & 0xfffffffffff,
 		};
 		let ppns = match self.addressing_mode {
 			AddressingMode::SV32 => [(pte >> 10) & 0x3ff, (pte >> 20) & 0xfff, 0 /*dummy*/],
-			AddressingMode::SV39 => [(pte >> 10) & 0x1ff, (pte >> 19) & 0x1ff, (pte >> 28) & 0x3ffffff],
-			_ => panic!() // Shouldn't happen
+			AddressingMode::SV39 => [
+				(pte >> 10) & 0x1ff,
+				(pte >> 19) & 0x1ff,
+				(pte >> 28) & 0x3ffffff,
+			],
+			_ => panic!(), // Shouldn't happen
 		};
 		let _rsw = (pte >> 8) & 0x3;
 		let d = (pte >> 7) & 1;
@@ -779,20 +838,25 @@ impl Mmu {
 		if r == 0 && x == 0 {
 			return match level {
 				0 => Err(()),
-				_ => self.traverse_page(v_address, level - 1, ppn, vpns, access_type)
+				_ => self.traverse_page(v_address, level - 1, ppn, vpns, access_type),
 			};
 		}
 
 		// Leaf page found
 
-		if a == 0 || (match access_type { MemoryAccessType::Write => d == 0, _ => false }) {
-			let new_pte = pte | (1 << 6) | (match access_type {
+		if a == 0
+			|| (match access_type {
+				MemoryAccessType::Write => d == 0,
+				_ => false,
+			}) {
+			let new_pte = pte
+				| (1 << 6) | (match access_type {
 				MemoryAccessType::Write => 1 << 7,
-				_ => 0
+				_ => 0,
 			});
 			match self.addressing_mode {
 				AddressingMode::SV32 => self.store_word_raw(pte_address, new_pte as u32),
-				_ => self.store_doubleword_raw(pte_address, new_pte)
+				_ => self.store_doubleword_raw(pte_address, new_pte),
 			};
 		}
 
@@ -801,22 +865,22 @@ impl Mmu {
 				if x == 0 {
 					return Err(());
 				}
-			},
+			}
 			MemoryAccessType::Read => {
 				if r == 0 {
 					return Err(());
 				}
-			},
+			}
 			MemoryAccessType::Write => {
 				if w == 0 {
 					return Err(());
 				}
-			},
+			}
 			_ => {}
 		};
 
 		let offset = v_address & 0xfff; // [11:0]
-		// @TODO: Optimize
+								  // @TODO: Optimize
 		let p_address = match self.addressing_mode {
 			AddressingMode::SV32 => match level {
 				1 => {
@@ -824,9 +888,9 @@ impl Mmu {
 						return Err(());
 					}
 					(ppns[1] << 22) | (vpns[0] << 12) | offset
-				},
+				}
 				0 => (ppn << 12) | offset,
-				_ => panic!() // Shouldn't happen
+				_ => panic!(), // Shouldn't happen
 			},
 			_ => match level {
 				2 => {
@@ -834,15 +898,15 @@ impl Mmu {
 						return Err(());
 					}
 					(ppns[2] << 30) | (vpns[1] << 21) | (vpns[0] << 12) | offset
-				},
+				}
 				1 => {
 					if ppns[0] != 0 {
 						return Err(());
 					}
 					(ppns[2] << 30) | (ppns[1] << 21) | (vpns[0] << 12) | offset
-				},
+				}
 				0 => (ppn << 12) | offset,
-				_ => panic!() // Shouldn't happen
+				_ => panic!(), // Shouldn't happen
 			},
 		};
 
@@ -869,13 +933,13 @@ impl Mmu {
 /// [`Memory`](../memory/struct.Memory.html) wrapper. Converts physical address to the one in memory
 /// using [`DRAM_BASE`](constant.DRAM_BASE.html) and accesses [`Memory`](../memory/struct.Memory.html).
 pub struct MemoryWrapper {
-	memory: Memory
+	memory: Memory,
 }
 
 impl MemoryWrapper {
 	fn new() -> Self {
 		MemoryWrapper {
-			memory: Memory::new()
+			memory: Memory::new(),
 		}
 	}
 
@@ -884,48 +948,74 @@ impl MemoryWrapper {
 	}
 
 	pub fn read_byte(&mut self, p_address: u64) -> u8 {
-		debug_assert!(p_address >= DRAM_BASE, "Memory address must equals to or bigger than DRAM_BASE. {:X}", p_address);
+		debug_assert!(
+			p_address >= DRAM_BASE,
+			"Memory address must equals to or bigger than DRAM_BASE. {:X}",
+			p_address
+		);
 		self.memory.read_byte(p_address - DRAM_BASE)
 	}
 
 	pub fn read_halfword(&mut self, p_address: u64) -> u16 {
-		debug_assert!(p_address >= DRAM_BASE && p_address.wrapping_add(1) >= DRAM_BASE,
-			"Memory address must equals to or bigger than DRAM_BASE. {:X}", p_address);
+		debug_assert!(
+			p_address >= DRAM_BASE && p_address.wrapping_add(1) >= DRAM_BASE,
+			"Memory address must equals to or bigger than DRAM_BASE. {:X}",
+			p_address
+		);
 		self.memory.read_halfword(p_address - DRAM_BASE)
 	}
 
 	pub fn read_word(&mut self, p_address: u64) -> u32 {
-		debug_assert!(p_address >= DRAM_BASE && p_address.wrapping_add(3) >= DRAM_BASE,
-			"Memory address must equals to or bigger than DRAM_BASE. {:X}", p_address);
+		debug_assert!(
+			p_address >= DRAM_BASE && p_address.wrapping_add(3) >= DRAM_BASE,
+			"Memory address must equals to or bigger than DRAM_BASE. {:X}",
+			p_address
+		);
 		self.memory.read_word(p_address - DRAM_BASE)
 	}
 
 	pub fn read_doubleword(&mut self, p_address: u64) -> u64 {
-		debug_assert!(p_address >= DRAM_BASE && p_address.wrapping_add(7) >= DRAM_BASE,
-			"Memory address must equals to or bigger than DRAM_BASE. {:X}", p_address);
+		debug_assert!(
+			p_address >= DRAM_BASE && p_address.wrapping_add(7) >= DRAM_BASE,
+			"Memory address must equals to or bigger than DRAM_BASE. {:X}",
+			p_address
+		);
 		self.memory.read_doubleword(p_address - DRAM_BASE)
 	}
 
 	pub fn write_byte(&mut self, p_address: u64, value: u8) {
-		debug_assert!(p_address >= DRAM_BASE, "Memory address must equals to or bigger than DRAM_BASE. {:X}", p_address);
+		debug_assert!(
+			p_address >= DRAM_BASE,
+			"Memory address must equals to or bigger than DRAM_BASE. {:X}",
+			p_address
+		);
 		self.memory.write_byte(p_address - DRAM_BASE, value)
 	}
 
 	pub fn write_halfword(&mut self, p_address: u64, value: u16) {
-		debug_assert!(p_address >= DRAM_BASE && p_address.wrapping_add(1) >= DRAM_BASE,
-			"Memory address must equals to or bigger than DRAM_BASE. {:X}", p_address);
+		debug_assert!(
+			p_address >= DRAM_BASE && p_address.wrapping_add(1) >= DRAM_BASE,
+			"Memory address must equals to or bigger than DRAM_BASE. {:X}",
+			p_address
+		);
 		self.memory.write_halfword(p_address - DRAM_BASE, value)
 	}
 
 	pub fn write_word(&mut self, p_address: u64, value: u32) {
-		debug_assert!(p_address >= DRAM_BASE && p_address.wrapping_add(3) >= DRAM_BASE,
-			"Memory address must equals to or bigger than DRAM_BASE. {:X}", p_address);
+		debug_assert!(
+			p_address >= DRAM_BASE && p_address.wrapping_add(3) >= DRAM_BASE,
+			"Memory address must equals to or bigger than DRAM_BASE. {:X}",
+			p_address
+		);
 		self.memory.write_word(p_address - DRAM_BASE, value)
 	}
 
 	pub fn write_doubleword(&mut self, p_address: u64, value: u64) {
-		debug_assert!(p_address >= DRAM_BASE && p_address.wrapping_add(7) >= DRAM_BASE,
-			"Memory address must equals to or bigger than DRAM_BASE. {:X}", p_address);
+		debug_assert!(
+			p_address >= DRAM_BASE && p_address.wrapping_add(7) >= DRAM_BASE,
+			"Memory address must equals to or bigger than DRAM_BASE. {:X}",
+			p_address
+		);
 		self.memory.write_doubleword(p_address - DRAM_BASE, value)
 	}
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -31,7 +31,11 @@ impl DummyTerminal {
 
 impl Terminal for DummyTerminal {
 	fn put_byte(&mut self, _value: u8) {}
-	fn get_input(&mut self) -> u8 { 0 }
+	fn get_input(&mut self) -> u8 {
+		0
+	}
 	fn put_input(&mut self, _value: u8) {}
-	fn get_output(&mut self) -> u8 { 0 }
+	fn get_output(&mut self) -> u8 {
+		0
+	}
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,11 +1,11 @@
-extern crate wasm_bindgen;
 extern crate riscv_emu_rust;
+extern crate wasm_bindgen;
 
-use wasm_bindgen::prelude::*;
 use std::collections::HashMap;
+use wasm_bindgen::prelude::*;
 
-use riscv_emu_rust::Emulator;
 use riscv_emu_rust::default_terminal::DefaultTerminal;
+use riscv_emu_rust::Emulator;
 
 /// `WasmRiscv` is an interface between user JavaScript code and
 /// WebAssembly RISC-V emulator. The following code is example
@@ -50,7 +50,7 @@ use riscv_emu_rust::default_terminal::DefaultTerminal;
 /// ```
 #[wasm_bindgen]
 pub struct WasmRiscv {
-	emulator: Emulator
+	emulator: Emulator,
 }
 
 #[wasm_bindgen]
@@ -58,7 +58,7 @@ impl WasmRiscv {
 	/// Creates a new `WasmRiscv`.
 	pub fn new() -> Self {
 		WasmRiscv {
-			emulator: Emulator::new(Box::new(DefaultTerminal::new()))
+			emulator: Emulator::new(Box::new(DefaultTerminal::new())),
 		}
 	}
 
@@ -180,25 +180,34 @@ impl WasmRiscv {
 	///        of valid memory address range)
 	pub fn load_doubleword(&mut self, address: u64, error: &mut [u8]) -> u64 {
 		for i in 0..8 {
-			match self.emulator.get_mut_cpu()
-				.get_mut_mmu().validate_address(address.wrapping_add(i)) {
+			match self
+				.emulator
+				.get_mut_cpu()
+				.get_mut_mmu()
+				.validate_address(address.wrapping_add(i))
+			{
 				Ok(valid) => {
 					if !valid {
 						error[0] = 2;
 						return 0;
 					}
-				},
+				}
 				Err(()) => {
 					error[0] = 1;
 					return 0;
 				}
 			}
 		}
-		match self.emulator.get_mut_cpu().get_mut_mmu().load_doubleword(address) {
+		match self
+			.emulator
+			.get_mut_cpu()
+			.get_mut_mmu()
+			.load_doubleword(address)
+		{
 			Ok(data) => {
 				error[0] = 0;
 				data
-			},
+			}
 			Err(_trap) => {
 				error[0] = 1;
 				0
@@ -268,7 +277,7 @@ impl WasmRiscv {
 			Some(address) => {
 				error[0] = 0;
 				address
-			},
+			}
 			None => {
 				error[0] = 1;
 				0


### PR DESCRIPTION
This PR adds support for the RISC-V Spike emulator and improves instruction compliance with the RISC-V specification.

Key Changes:
1. Added support for RV64IM instruction set
   - Updated physical address size to 56 bits for RV64 compliance
   - Fixed shift amount masking for RV64 instructions

2. Fixed AMO instruction implementation
   - Added proper shift amount masking for SRL instruction
   - Fixed sign extension handling in word operations
   - Improved alignment requirements for AMO operations

3. Improved CSR handling
   - Added proper read-only CSR checks
   - Enhanced privilege mode transitions

Testing:
- Verified against RISC-V architectural test suite
- Tested with both RV32IM and RV64IM configurations
- Validated AMO instruction behavior matches Spike emulator

Note: This PR focuses on making the implementation more compliant with the RISC-V specification while maintaining compatibility with existing code.